### PR TITLE
Add Flutter mobile app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Angel Stones
 
 PHP and HTML5 based product catalog and showcase application.
+For mobile users, a Flutter app skeleton is available in `mobile_app/`. See that directory for setup instructions.
 
 ## SEO Features
 

--- a/mobile_app/README.md
+++ b/mobile_app/README.md
@@ -1,0 +1,34 @@
+# Angel Stones Mobile App
+
+This folder contains a Flutter project that provides a basic mobile application for Angel Stones. The code is intentionally lightweight so it can be edited without a full Flutter installation.
+
+## Project Structure
+
+- `lib/` – Dart source files
+  - `main.dart` – entry point with route setup
+  - `models/` – data models used in the app
+  - `services/` – API and local storage helpers
+  - `screens/` – UI screens such as home, detail, cart, and contact
+- `test/` – example widget test
+
+## Running the App
+
+1. Install Flutter on your development machine.
+2. From the `mobile_app` directory run:
+   ```bash
+   flutter pub get
+   flutter run
+   ```
+
+## Building for Release
+
+To generate an APK for Android:
+```bash
+flutter build apk --release
+```
+
+To generate an IPA for iOS (requires macOS):
+```bash
+flutter build ios --release
+```
+

--- a/mobile_app/analysis_options.yaml
+++ b/mobile_app/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'models/product.dart';
+import 'services/api_service.dart';
+import 'services/storage_service.dart';
+import 'screens/home_screen.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Angel Stones',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: HomeScreen(
+        apiService: ApiService(),
+        storageService: StorageService(),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/models/cart_item.dart
+++ b/mobile_app/lib/models/cart_item.dart
@@ -1,0 +1,10 @@
+import 'product.dart';
+
+class CartItem {
+  final Product product;
+  int quantity;
+
+  CartItem({required this.product, this.quantity = 1});
+
+  double get total => product.price * quantity;
+}

--- a/mobile_app/lib/models/product.dart
+++ b/mobile_app/lib/models/product.dart
@@ -1,0 +1,25 @@
+class Product {
+  final String id;
+  final String name;
+  final String description;
+  final String imageUrl;
+  final double price;
+
+  Product({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.imageUrl,
+    required this.price,
+  });
+
+  factory Product.fromJson(Map<String, dynamic> json) {
+    return Product(
+      id: json['id'].toString(),
+      name: json['name'] ?? '',
+      description: json['description'] ?? '',
+      imageUrl: json['image'] ?? '',
+      price: double.tryParse(json['price'].toString()) ?? 0.0,
+    );
+  }
+}

--- a/mobile_app/lib/screens/cart_screen.dart
+++ b/mobile_app/lib/screens/cart_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class CartScreen extends StatelessWidget {
+  const CartScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cart')),
+      body: const Center(child: Text('Cart items will appear here')),
+    );
+  }
+}

--- a/mobile_app/lib/screens/contact_screen.dart
+++ b/mobile_app/lib/screens/contact_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ContactScreen extends StatelessWidget {
+  const ContactScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Contact')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            Text('Email: sales@theangelstones.com'),
+            SizedBox(height: 8),
+            Text('Address: 123 Stone Way, Granite City'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/screens/home_screen.dart
+++ b/mobile_app/lib/screens/home_screen.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import '../models/product.dart';
+import '../services/api_service.dart';
+import '../services/storage_service.dart';
+import 'product_detail_screen.dart';
+import 'cart_screen.dart';
+import 'contact_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  final ApiService apiService;
+  final StorageService storageService;
+
+  const HomeScreen({super.key, required this.apiService, required this.storageService});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  late Future<List<Product>> _futureProducts;
+
+  @override
+  void initState() {
+    super.initState();
+    _futureProducts = _loadProducts();
+  }
+
+  Future<List<Product>> _loadProducts() async {
+    final cached = await widget.storageService.loadProducts();
+    if (cached != null) {
+      return cached;
+    }
+    final products = await widget.apiService.fetchProducts();
+    await widget.storageService.saveProducts(products);
+    return products;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Angel Stones'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.shopping_cart),
+            onPressed: () {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const CartScreen()));
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.contact_page),
+            onPressed: () {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const ContactScreen()));
+            },
+          )
+        ],
+      ),
+      body: FutureBuilder<List<Product>>(
+        future: _futureProducts,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('No products found'));
+          }
+          final products = snapshot.data!;
+          return GridView.builder(
+            padding: const EdgeInsets.all(8),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              childAspectRatio: 0.75,
+            ),
+            itemCount: products.length,
+            itemBuilder: (context, index) {
+              final product = products[index];
+              return GestureDetector(
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ProductDetailScreen(product: product),
+                    ),
+                  );
+                },
+                child: Card(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(
+                        child: Image.network(
+                          product.imageUrl,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Text(product.name, style: const TextStyle(fontSize: 16)),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/screens/product_detail_screen.dart
+++ b/mobile_app/lib/screens/product_detail_screen.dart
@@ -1,0 +1,54 @@
+cat > mobile_app/lib/screens/product_detail_screen.dart <<'EOF'
+cat > mobile_app/lib/screens/product_detail_screen.dart <<'EOF'
+cat <<'EOF' > /tmp/pds.b64
+aW1wb3J0ICdwYWNrYWdlOmZsdXR0ZXIvbWF0ZXJpYWwuZGFydCc7CmltcG9ydCcuLi9tb2RlbHMvcHJvZHVjdC5kYXJ0JzsKaW1wb3J0ICdjYXJ0X3NjcmVlbi5kYXJ0JzsKCmNsYXNzIFByb2R1Y3REZXRhaWxTY3JlZW4gZXh0ZW5kcyBTdGF0ZWxlc3NXaWRnZXQgewogIGZpbmFsIFByb2R1Y3QgcHJvZHVjdDsKCiAgY29uc3QgUHJvZHVjdERldGFpbFNjcmVlbih7c3VwZXIua2V5LCByZXF1aXJlZCB0aGlzLnByb2R1Y3R9KTsKCiAgQG92ZXJyaWRlCiAgV2lkZ2V0IGJ1aWxkKEJ1aWxkQ29udGV4dCBjb250ZXh0KSB7CiAgICByZXR1cm4gU2NhZmZvbGQ(-CiAgICAgIGFwcEJhckFwcChcbiAgICAgICAgdGl0bGU6IFRleHQocHJvZHVjdC5uYW1lKSxcbiAgICAgICAgYWN0aW9uczogW1xuICAgICAgICAgIEljb25CdXR0b24oXG4gICAgICAgICAgICBjb24qXCAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIA==
+cat <<'EOF' > mobile_app/lib/screens/product_detail_screen.dart
+import 'package:flutter/material.dart';
+import '../models/product.dart';
+import 'cart_screen.dart';
+
+class ProductDetailScreen extends StatelessWidget {
+  final Product product;
+
+  const ProductDetailScreen({super.key, required this.product});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(product.name),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.shopping_cart),
+            onPressed: () {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const CartScreen()));
+            },
+          )
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Image.network(product.imageUrl, height: 200, fit: BoxFit.cover),
+            const SizedBox(height: 16),
+            Text(product.name, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Text('''\$${product.price.toStringAsFixed(2)}''', style: const TextStyle(fontSize: 18)),
+            const SizedBox(height: 8),
+            Text(product.description),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                // Add to cart logic would go here
+                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Added to cart')));
+              },
+              child: const Text('Add to Cart'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/product.dart';
+
+class ApiService {
+  static const _baseUrl = 'https://theangelstones.com';
+
+  Future<List<Product>> fetchProducts() async {
+    final uri = Uri.parse('$_baseUrl/api/color.json');
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      final List<dynamic> data = json.decode(response.body);
+      return data.map((e) => Product.fromJson(e)).toList();
+    } else {
+      throw Exception('Failed to load products');
+    }
+  }
+}

--- a/mobile_app/lib/services/storage_service.dart
+++ b/mobile_app/lib/services/storage_service.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/product.dart';
+
+class StorageService {
+  static const _cacheKey = 'cached_products';
+
+  Future<void> saveProducts(List<Product> products) async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonData = json.encode(products.map((p) => {
+          'id': p.id,
+          'name': p.name,
+          'description': p.description,
+          'image': p.imageUrl,
+          'price': p.price,
+        }).toList());
+    await prefs.setString(_cacheKey, jsonData);
+  }
+
+  Future<List<Product>?> loadProducts() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonData = prefs.getString(_cacheKey);
+    if (jsonData != null) {
+      final List<dynamic> data = json.decode(jsonData);
+      return data.map((e) => Product.fromJson(e)).toList();
+    }
+    return null;
+  }
+}

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,0 +1,21 @@
+name: angel_stones_app
+description: Mobile app for Angel Stones.
+version: 0.1.0
+
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  http: ^1.1.0
+  shared_preferences: ^2.2.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true

--- a/mobile_app/test/widget_test.dart
+++ b/mobile_app/test/widget_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:angel_stones_app/main.dart';
+
+void main() {
+  testWidgets('App loads', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    expect(find.text('Angel Stones'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- create `mobile_app` Flutter skeleton for Android/iOS
- describe mobile app directory in README

## Testing
- `npm install`
- `npx playwright test` *(fails: cannot reach http://localhost:8000)*

------
https://chatgpt.com/codex/tasks/task_e_685c8f68d76c83279e4e2d0251ac5e34