### PR TITLE
Add glowing border for products and colors

### DIFF
--- a/css/specials/specials.css
+++ b/css/specials/specials.css
@@ -196,3 +196,40 @@
     box-shadow: inset 0 0 5px #666;
     font-weight: bold;
 }
+
+/* Animated glowing border used for specials cards */
+.glowing-border {
+    position: relative;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.glowing-border::before,
+.glowing-border::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    padding: 2px;
+    background: conic-gradient(from var(--deg, 0deg) at center,
+        #00c3ff,
+        #4d01f9,
+        #a630c6,
+        #00c3ff);
+    animation: autoRotate 6s linear infinite;
+    pointer-events: none;
+    z-index: -2;
+}
+
+.glowing-border::after {
+    filter: blur(10px);
+}
+
+@keyframes autoRotate {
+    to {
+        --deg: 360deg;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1013,7 +1013,7 @@
                         <div class="category-grid" id="category-grid">
                             <!-- Remove the carousel structure causing the display issues -->
                             <!-- Hardcoded fallback categories -->
-                            <div class="category-item">
+                            <div class="category-item glowing-border">
                                 <a href="?category=mbna_2025" class="category-link" data-collection="mbna_2025-collection">
                                     <div class="category-image">
                                         <img src="images/products/MBNA_2025/AG-116.jpg" alt="MBNA 2025" loading="lazy" onerror="this.src='images/default-thumbnail.jpg'">
@@ -1022,7 +1022,7 @@
                                     <span class="category-count">26 Designs</span>
                                 </a>
                             </div>
-                            <div class="category-item">
+                            <div class="category-item glowing-border">
                                 <a href="?category=monuments" class="category-link" data-collection="monuments-collection">
                                     <div class="category-image">
                                         <img src="images/products/Monuments/granite-monuments-project02.jpg" alt="Monuments" loading="lazy" onerror="this.src='images/default-thumbnail.jpg'">
@@ -1031,7 +1031,7 @@
                                     <span class="category-count">28 Designs</span>
                                 </a>
                             </div>
-                            <div class="category-item">
+                            <div class="category-item glowing-border">
                                 <a href="?category=columbarium" class="category-link" data-collection="columbarium-collection">
                                     <div class="category-image">
                                         <img src="images/products/columbarium/customized-designs-project03.jpg" alt="Columbarium" loading="lazy" onerror="this.src='images/default-thumbnail.jpg'">
@@ -1040,7 +1040,7 @@
                                     <span class="category-count">1 Design</span>
                                 </a>
                             </div>
-                            <div class="category-item">
+                            <div class="category-item glowing-border">
                                 <a href="?category=designs" class="category-link" data-collection="Designs-collection">
                                     <div class="category-image">
                                         <img src="images/products/Designs/chess.jpg" alt="Designs" loading="lazy" onerror="this.src='images/default-thumbnail.jpg'">
@@ -1049,7 +1049,7 @@
                                     <span class="category-count">1 Designs</span>
                                 </a>
                             </div>
-                            <div class="category-item">
+                            <div class="category-item glowing-border">
                                 <a href="?category=benches" class="category-link" data-collection="benches-collection">
                                     <div class="category-image">
                                         <img src="images/products/Benches/Fountain2.jpg" alt="Benches" loading="lazy" onerror="this.src='images/default-thumbnail.jpg'">
@@ -1674,7 +1674,7 @@
                             const specialCard = document.createElement('div');
                             specialCard.className = 'col-md-6 col-lg-4 mb-4';
                             specialCard.innerHTML = `
-                                <div class="special-card" data-special-id="${special.id}" style="cursor: pointer;">
+                                <div class="special-card glowing-border" data-special-id="${special.id}" style="cursor: pointer;">
                                     <div class="special-image">
                                         <img src="${special.thumbnail}" alt="${special.title}" class="img-fluid">
                                         <div class="special-overlay">

--- a/js/color-carousel.js
+++ b/js/color-carousel.js
@@ -122,9 +122,10 @@
             
             // Create color item with schema.org attributes
             const item = `
-                <div class="color-item" 
-                     itemprop="itemListElement" 
-                     itemscope 
+                <div class="color-scroll-item variety-of-granites glowing-border"
+                     
+                     itemprop="itemListElement"
+                     itemscope
                      itemtype="https://schema.org/ListItem"
                      data-color-name="${color.name}">
                     <meta itemprop="position" content="${index + 1}" />

--- a/js/color-carousel.min.js
+++ b/js/color-carousel.min.js
@@ -158,7 +158,7 @@ function populateColorDisplay(){
     validColors.forEach((color, index) => {
         // Create the item element
         const itemEl = document.createElement('div');
-        itemEl.className = 'color-scroll-item variety-of-granites';
+        itemEl.className = 'color-scroll-item variety-of-granites glowing-border';
         itemEl.setAttribute('data-index', index);
         itemEl.setAttribute('role', 'group');
         itemEl.setAttribute('aria-label', `${color.name} color option`);

--- a/js/product-categories-fixed.min.js
+++ b/js/product-categories-fixed.min.js
@@ -52,7 +52,7 @@ document.addEventListener("DOMContentLoaded",function(){
     t.innerHTML="";
     Object.keys(e).forEach(function(n){
       const o=document.createElement("div");
-      o.className="category-item";
+      o.className="category-item glowing-border";
       o.innerHTML=`
                 <a href="#${n.toLowerCase()}-collection" class="category-link">
                     <div class="category-image">

--- a/js/product-categories.js
+++ b/js/product-categories.js
@@ -193,7 +193,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         Object.entries(categories).forEach(([category, images]) => {
             const categoryItem = document.createElement('div');
-            categoryItem.className = 'category-item';
+            categoryItem.className = 'category-item glowing-border';
 
             const link = document.createElement('a');
             link.href = `#${category.toLowerCase()}-collection`;

--- a/js/specials/specials-loader.js
+++ b/js/specials/specials-loader.js
@@ -61,7 +61,7 @@ const SpecialsModule = (function() {
             specialCol.className = 'col-md-6 col-lg-4 mb-4';
             
             const specialCard = document.createElement('div');
-            specialCard.className = 'special-card h-100';
+            specialCard.className = 'special-card h-100 glowing-border';
             specialCard.dataset.specialId = special.id;
             
             // Create card content


### PR DESCRIPTION
## Summary
- extend `glowing-border` class to product category cards
- apply animated border to color carousel items
- update minified JS files accordingly
- refine glowing border CSS to avoid flicker

## Testing
- `npm install`
- `npx playwright test` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c5f9939dc8327bc2ee71fc80541d1