### PR TITLE
Handle JSON object response and update NDK

### DIFF
--- a/mobile_app/android/app/build.gradle.kts
+++ b/mobile_app/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.angel_stones_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/mobile_app/lib/models/product.dart
+++ b/mobile_app/lib/models/product.dart
@@ -14,12 +14,31 @@ class Product {
   });
 
   factory Product.fromJson(Map<String, dynamic> json) {
+    final Map<String, dynamic> data =
+        json.containsKey('item') ? json['item'] as Map<String, dynamic> : json;
+
+    String imageUrl = '';
+    final imageField = data['image'];
+    if (imageField is List && imageField.isNotEmpty) {
+      final first = imageField.first;
+      if (first is Map<String, dynamic>) {
+        imageUrl = first['url'] ?? '';
+      } else if (first is String) {
+        imageUrl = first;
+      }
+    } else if (imageField is String) {
+      imageUrl = imageField;
+    }
+
+    final priceField =
+        (data['offers'] is Map) ? (data['offers']['price']) : data['price'];
+
     return Product(
-      id: json['id'].toString(),
-      name: json['name'] ?? '',
-      description: json['description'] ?? '',
-      imageUrl: json['image'] ?? '',
-      price: double.tryParse(json['price'].toString()) ?? 0.0,
+      id: (data['sku'] ?? data['id'] ?? '').toString(),
+      name: data['name'] ?? '',
+      description: data['description'] ?? '',
+      imageUrl: imageUrl,
+      price: double.tryParse(priceField?.toString() ?? '') ?? 0.0,
     );
   }
 }

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -9,8 +9,12 @@ class ApiService {
     final uri = Uri.parse('$_baseUrl/api/color.json');
     final response = await http.get(uri);
     if (response.statusCode == 200) {
-      final List<dynamic> data = json.decode(response.body);
-      return data.map((e) => Product.fromJson(e)).toList();
+      final Map<String, dynamic> jsonData = json.decode(response.body);
+      final List<dynamic> items = jsonData['itemListElement'] ?? [];
+      return items
+          .whereType<Map<String, dynamic>>()
+          .map((e) => Product.fromJson(e['item'] as Map<String, dynamic>))
+          .toList();
     } else {
       throw Exception('Failed to load products');
     }


### PR DESCRIPTION
## Summary
- adjust API service to parse JSON object that contains `itemListElement`
- relax `Product.fromJson` to support API object shape
- update Android build to use NDK 27.0.12077973

## Testing
- `npm install`
- `npx playwright install` *(fails: domain forbidden)*
- `npx playwright test` *(fails: domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687599a38b60832785d879f8b95e0143