### PR TITLE
Revamp mobile homepage layout

### DIFF
--- a/mobile_app/lib/models/product.dart
+++ b/mobile_app/lib/models/product.dart
@@ -5,6 +5,7 @@ class Product {
   final String imageUrl;
   final double price;
   final String? label;
+  final String? pdfUrl;
 
   Product({
     required this.id,
@@ -13,6 +14,7 @@ class Product {
     required this.imageUrl,
     required this.price,
     this.label,
+    this.pdfUrl,
   });
 
   factory Product.fromJson(Map<String, dynamic> json) {
@@ -51,6 +53,7 @@ class Product {
       imageUrl: imageUrl,
       price: double.tryParse(priceField?.toString() ?? '') ?? 0.0,
       label: label,
+      pdfUrl: data['pdf']?.toString(),
     );
   }
 }

--- a/mobile_app/lib/screens/design_gallery_screen.dart
+++ b/mobile_app/lib/screens/design_gallery_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import '../services/api_service.dart';
+
+class DesignGalleryScreen extends StatelessWidget {
+  final String categoryId;
+  final String title;
+  final ApiService apiService;
+
+  const DesignGalleryScreen({super.key, required this.categoryId, required this.title, required this.apiService});
+
+  @override
+  Widget build(BuildContext context) {
+    final futureImages = apiService.fetchCategoryImages(categoryId);
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: FutureBuilder<List<String>>(
+        future: futureImages,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('No designs found'));
+          }
+          final images = snapshot.data!;
+          return GridView.builder(
+            padding: const EdgeInsets.all(8),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              childAspectRatio: 1,
+              crossAxisSpacing: 8,
+              mainAxisSpacing: 8,
+            ),
+            itemCount: images.length,
+            itemBuilder: (context, index) {
+              final url = images[index];
+              return Image.network(
+                url,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stack) => const Icon(Icons.broken_image),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/mobile_app/lib/screens/flyer_viewer_screen.dart
+++ b/mobile_app/lib/screens/flyer_viewer_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+import '../models/product.dart';
+
+class FlyerViewerScreen extends StatelessWidget {
+  final Product flyer;
+  const FlyerViewerScreen({super.key, required this.flyer});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(flyer.name)),
+      body: Column(
+        children: [
+          Expanded(
+            child: InteractiveViewer(
+              child: Image.network(
+                flyer.imageUrl,
+                fit: BoxFit.contain,
+                errorBuilder: (context, error, stack) => const Center(child: Icon(Icons.broken_image)),
+              ),
+            ),
+          ),
+          if (flyer.pdfUrl != null)
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: ElevatedButton(
+                onPressed: () => launchUrlString(flyer.pdfUrl!),
+                child: const Text('Open PDF'),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/mobile_app/lib/screens/home_screen.dart
+++ b/mobile_app/lib/screens/home_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import '../models/product.dart';
 import '../services/api_service.dart';
 import '../services/storage_service.dart';
-import '../widgets/product_section.dart';
+import '../widgets/flyer_section.dart';
+import '../widgets/product_folder_section.dart';
+import '../widgets/inventory_table_section.dart';
 
 class HomeScreen extends StatefulWidget {
   final ApiService apiService;
@@ -36,15 +38,16 @@ class _HomeScreenState extends State<HomeScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          ProductSection(
+          FlyerSection(
             title: 'Flyers',
             future: _futureSpecials,
           ),
-          ProductSection(
+          ProductFolderSection(
             title: 'Featured Products',
             future: _futureFeatured,
+            apiService: widget.apiService,
           ),
-          ProductSection(
+          InventoryTableSection(
             title: 'Current Inventory',
             future: _futureInventory,
           ),

--- a/mobile_app/lib/screens/inventory_screen.dart
+++ b/mobile_app/lib/screens/inventory_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/product.dart';
 import '../services/api_service.dart';
-import '../widgets/product_section.dart';
+import '../widgets/inventory_table_section.dart';
 
 class InventoryScreen extends StatefulWidget {
   final ApiService apiService;
@@ -23,7 +23,7 @@ class _InventoryScreenState extends State<InventoryScreen> {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: ProductSection(
+      child: InventoryTableSection(
         title: 'Current Inventory',
         future: _futureInventory,
       ),

--- a/mobile_app/lib/screens/product_detail_screen.dart
+++ b/mobile_app/lib/screens/product_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import '../models/product.dart';
-import 'cart_screen.dart';
 
 class ProductDetailScreen extends StatelessWidget {
   final Product product;
@@ -12,14 +11,7 @@ class ProductDetailScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(product.name),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.shopping_cart),
-            onPressed: () {
-              Navigator.push(context, MaterialPageRoute(builder: (_) => const CartScreen()));
-            },
-          )
-        ],
+        actions: const [],
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
@@ -30,20 +22,11 @@ class ProductDetailScreen extends StatelessWidget {
             const SizedBox(height: 16),
             Text(product.name, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
-            Text('''\$${product.price.toStringAsFixed(2)}''', style: const TextStyle(fontSize: 18)),
-            const SizedBox(height: 8),
             Text(product.description),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () {
-                // Add to cart logic would go here
-                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Added to cart')));
-              },
-              child: const Text('Add to Cart'),
-            ),
           ],
         ),
       ),
     );
   }
 }
+

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -6,6 +6,21 @@ import '../models/product.dart';
 class ApiService {
   static const _baseUrl = 'https://theangelstones.com';
 
+  Future<List<String>> fetchCategoryImages(String category) async {
+    final uri = Uri.parse('$_baseUrl/get_directory_files.php?directory=products/$category');
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonData = json.decode(response.body);
+      final List<dynamic> files = jsonData['files'] ?? [];
+      return files
+          .whereType<Map<String, dynamic>>()
+          .map((e) => '$_baseUrl/' + (e['path'] ?? '').toString())
+          .toList();
+    } else {
+      throw Exception('Failed to load category images');
+    }
+  }
+
   Future<List<Product>> fetchProducts() async {
     final uri = Uri.parse('$_baseUrl/api/color.json');
     final response = await http.get(uri);

--- a/mobile_app/lib/widgets/flyer_section.dart
+++ b/mobile_app/lib/widgets/flyer_section.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import '../models/product.dart';
+import '../screens/flyer_viewer_screen.dart';
+
+class FlyerSection extends StatelessWidget {
+  final String title;
+  final Future<List<Product>> future;
+  const FlyerSection({super.key, required this.title, required this.future});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          FutureBuilder<List<Product>>(
+            future: future,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              } else if (snapshot.hasError) {
+                return Text('Error: ${snapshot.error}');
+              } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                return const Text('No flyers found');
+              }
+              final flyers = snapshot.data!;
+              return GridView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  childAspectRatio: 0.75,
+                ),
+                itemCount: flyers.length,
+                itemBuilder: (context, index) {
+                  final flyer = flyers[index];
+                  return GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => FlyerViewerScreen(flyer: flyer),
+                        ),
+                      );
+                    },
+                    child: Card(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            child: Image.network(
+                              flyer.imageUrl,
+                              fit: BoxFit.cover,
+                              errorBuilder: (context, error, stack) => const Icon(Icons.broken_image),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Text(flyer.name, style: const TextStyle(fontSize: 16)),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/mobile_app/lib/widgets/inventory_table_section.dart
+++ b/mobile_app/lib/widgets/inventory_table_section.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import '../models/product.dart';
+
+class InventoryTableSection extends StatelessWidget {
+  final String title;
+  final Future<List<Product>> future;
+  const InventoryTableSection({super.key, required this.title, required this.future});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          FutureBuilder<List<Product>>(
+            future: future,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              } else if (snapshot.hasError) {
+                return Text('Error: ${snapshot.error}');
+              } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                return const Text('No items found');
+              }
+              final items = snapshot.data!;
+              return SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: DataTable(
+                  columns: const [
+                    DataColumn(label: Text('Code')),
+                    DataColumn(label: Text('Description')),
+                    DataColumn(label: Text('Color')),
+                    DataColumn(label: Text('Size')),
+                    DataColumn(label: Text('Status')),
+                  ],
+                  rows: items.map((item) {
+                    return DataRow(cells: [
+                      DataCell(Text(item.id)),
+                      DataCell(Text(item.name)),
+                      const DataCell(Text('N/A')),
+                      const DataCell(Text('N/A')),
+                      const DataCell(Text('In Stock')),
+                    ]);
+                  }).toList(),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/mobile_app/lib/widgets/product_folder_section.dart
+++ b/mobile_app/lib/widgets/product_folder_section.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import '../models/product.dart';
+import '../screens/design_gallery_screen.dart';
+import '../services/api_service.dart';
+
+class ProductFolderSection extends StatelessWidget {
+  final String title;
+  final Future<List<Product>> future;
+  final ApiService apiService;
+  const ProductFolderSection({super.key, required this.title, required this.future, required this.apiService});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          FutureBuilder<List<Product>>(
+            future: future,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              } else if (snapshot.hasError) {
+                return Text('Error: ${snapshot.error}');
+              } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                return const Text('No items found');
+              }
+              final categories = snapshot.data!;
+              return GridView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  childAspectRatio: 0.75,
+                ),
+                itemCount: categories.length,
+                itemBuilder: (context, index) {
+                  final product = categories[index];
+                  return GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => DesignGalleryScreen(
+                            categoryId: product.id,
+                            title: product.name,
+                            apiService: apiService,
+                          ),
+                        ),
+                      );
+                    },
+                    child: Card(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            child: Image.network(
+                              product.imageUrl,
+                              fit: BoxFit.cover,
+                              errorBuilder: (context, error, stack) => const Icon(Icons.broken_image),
+                            ),
+                          ),
+                          if (product.label != null && product.label!.isNotEmpty)
+                            Container(
+                              color: Colors.blueAccent,
+                              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                              child: Text(
+                                product.label!,
+                                style: const TextStyle(color: Colors.white, fontSize: 12),
+                              ),
+                            ),
+                          Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Text(product.name, style: const TextStyle(fontSize: 16)),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   http: ^1.1.0
   shared_preferences: ^2.2.0
+  url_launcher: ^6.1.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `pdfUrl` field to product model
- implement flyer, product category and inventory table widgets
- remove cart actions from product detail screen
- create flyer viewer and design gallery screens
- load new sections in `HomeScreen`
- expose API method to fetch product folder images
- add url_launcher dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a7d474648327b01a62f07f73932c