### PR TITLE
Fix design count logic and inventory error handling

### DIFF
--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'services/api_service.dart';
 import 'services/storage_service.dart';
 import 'services/inventory_service.dart';
+import 'services/directory_service.dart';
 import 'screens/home_screen.dart';
 import 'screens/colors_screen.dart';
 import 'screens/inventory_screen.dart';
@@ -37,6 +38,7 @@ class _MainNavigationState extends State<MainNavigation> {
   final ApiService _apiService = ApiService();
   final StorageService _storageService = StorageService();
   final InventoryService _inventoryService = InventoryService();
+  final DirectoryService _directoryService = DirectoryService();
 
   late final List<Widget> _pages;
 
@@ -49,6 +51,7 @@ class _MainNavigationState extends State<MainNavigation> {
         apiService: _apiService,
         storageService: _storageService,
         inventoryService: _inventoryService,
+        directoryService: _directoryService,
         onViewFullInventory: () => setState(() => _currentIndex = 2),
       ),
       ColorsScreen(

--- a/mobile_app/lib/screens/home_screen.dart
+++ b/mobile_app/lib/screens/home_screen.dart
@@ -4,6 +4,7 @@ import '../services/api_service.dart';
 import '../services/storage_service.dart';
 import '../widgets/flyer_section.dart';
 import '../widgets/product_folder_section.dart';
+import '../services/directory_service.dart';
 import '../models/inventory_item.dart';
 import '../services/inventory_service.dart';
 
@@ -11,6 +12,7 @@ class HomeScreen extends StatefulWidget {
   final ApiService apiService;
   final StorageService storageService;
   final InventoryService inventoryService;
+  final DirectoryService directoryService;
   final VoidCallback onViewFullInventory;
 
   const HomeScreen({
@@ -18,6 +20,7 @@ class HomeScreen extends StatefulWidget {
     required this.apiService,
     required this.storageService,
     required this.inventoryService,
+    required this.directoryService,
     required this.onViewFullInventory,
   });
 
@@ -29,6 +32,7 @@ class _HomeScreenState extends State<HomeScreen> {
   late Future<List<Product>> _futureFeatured;
   late Future<List<InventoryItem>> _futureInventorySummary;
   late Future<List<Product>> _futureSpecials;
+  late DirectoryService _directoryService;
 
   @override
   void initState() {
@@ -39,6 +43,7 @@ class _HomeScreenState extends State<HomeScreen> {
         widget.inventoryService.fetchInventory(pageSize: 3);
     _futureSpecials =
         widget.apiService.loadLocalProducts('assets/specials.json');
+    _directoryService = widget.directoryService;
   }
 
   @override
@@ -55,6 +60,7 @@ class _HomeScreenState extends State<HomeScreen> {
             title: 'Featured Products',
             future: _futureFeatured,
             apiService: widget.apiService,
+            directoryService: _directoryService,
           ),
           Padding(
             padding: const EdgeInsets.all(8.0),

--- a/mobile_app/lib/screens/inventory_screen.dart
+++ b/mobile_app/lib/screens/inventory_screen.dart
@@ -17,7 +17,13 @@ class _InventoryScreenState extends State<InventoryScreen> {
   @override
   void initState() {
     super.initState();
-    _futureInventory = widget.inventoryService.fetchInventory(pageSize: 100);
+    _loadInventory();
+  }
+
+  void _loadInventory() {
+    setState(() {
+      _futureInventory = widget.inventoryService.fetchInventory(pageSize: 100);
+    });
   }
 
   @override
@@ -26,6 +32,7 @@ class _InventoryScreenState extends State<InventoryScreen> {
       child: InventoryTableSection(
         title: 'Current Inventory',
         future: _futureInventory,
+        onRetry: _loadInventory,
       ),
     );
   }

--- a/mobile_app/lib/services/directory_service.dart
+++ b/mobile_app/lib/services/directory_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter/foundation.dart';
+
+class DirectoryService {
+  static const String _baseUrl = 'https://theangelstones.com';
+  final Map<String, int> _countCache = {};
+
+  Future<int> fetchDesignCount(String folder) async {
+    if (_countCache.containsKey(folder)) {
+      return _countCache[folder]!;
+    }
+    final uri = Uri.parse('\$_baseUrl/get_directory_files.php?dir=$folder');
+    try {
+      final response = await http.get(uri);
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> data = json.decode(response.body);
+        final List<dynamic> files = data['files'] ?? [];
+        final count = files
+            .whereType<Map<String, dynamic>>()
+            .where((e) {
+              final path = (e['path'] ?? '').toString().toLowerCase();
+              return path.endsWith('.jpg') ||
+                  path.endsWith('.jpeg') ||
+                  path.endsWith('.png');
+            })
+            .length;
+        _countCache[folder] = count;
+        return count;
+      } else {
+        throw Exception('Failed to load directory files');
+      }
+    } catch (e) {
+      debugPrint('Error fetching design count for \$folder: \$e');
+      rethrow;
+    }
+  }
+
+  void clearCache() => _countCache.clear();
+}

--- a/mobile_app/lib/services/inventory_service.dart
+++ b/mobile_app/lib/services/inventory_service.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:http/http.dart' as http;
+import 'package:flutter/foundation.dart';
 import '../models/inventory_item.dart';
 
 class InventoryService {
@@ -7,16 +9,30 @@ class InventoryService {
 
   Future<List<InventoryItem>> fetchInventory({int page = 1, int pageSize = 100}) async {
     final uri = Uri.parse('$_baseUrl/inventory-proxy.php?page=$page&pageSize=$pageSize');
-    final response = await http.get(uri);
-    if (response.statusCode == 200) {
-      final data = json.decode(response.body);
-      final items = (data['data'] ?? data['Data'] ?? []) as List<dynamic>;
-      return items
-          .whereType<Map<String, dynamic>>()
-          .map((e) => InventoryItem.fromJson(e))
-          .toList();
-    } else {
-      throw Exception('Failed to load inventory');
+    try {
+      final response = await http.get(uri);
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final items = (data['data'] ?? data['Data'] ?? []) as List<dynamic>;
+        return items
+            .whereType<Map<String, dynamic>>()
+            .map((e) => InventoryItem.fromJson(e))
+            .toList();
+      } else {
+        throw HttpException('Status code ${response.statusCode}');
+      }
+    } on SocketException catch (e) {
+      debugPrint('SocketException while loading inventory: $e');
+      throw Exception('Unable to load inventory');
+    } on HttpException catch (e) {
+      debugPrint('HttpException while loading inventory: $e');
+      throw Exception('Unable to load inventory');
+    } on FormatException catch (e) {
+      debugPrint('FormatException while loading inventory: $e');
+      throw Exception('Unable to load inventory');
+    } catch (e) {
+      debugPrint('Unknown error while loading inventory: $e');
+      throw Exception('Unable to load inventory');
     }
   }
 }

--- a/mobile_app/lib/widgets/inventory_table_section.dart
+++ b/mobile_app/lib/widgets/inventory_table_section.dart
@@ -4,7 +4,13 @@ import '../models/inventory_item.dart';
 class InventoryTableSection extends StatelessWidget {
   final String title;
   final Future<List<InventoryItem>> future;
-  const InventoryTableSection({super.key, required this.title, required this.future});
+  final VoidCallback onRetry;
+  const InventoryTableSection({
+    super.key,
+    required this.title,
+    required this.future,
+    required this.onRetry,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +27,21 @@ class InventoryTableSection extends StatelessWidget {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(child: CircularProgressIndicator());
               } else if (snapshot.hasError) {
-                return Text('Error: ${snapshot.error}');
+                debugPrint('Inventory load error: ${snapshot.error}');
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Unable to load inventory at the moment.',
+                      style: TextStyle(color: Colors.red),
+                    ),
+                    const Text('Please check your internet connection or try again.'),
+                    TextButton(
+                      onPressed: onRetry,
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                );
               } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
                 return const Text('No items found');
               }


### PR DESCRIPTION
## Summary
- add `DirectoryService` to fetch directory image counts
- show dynamic design counts in `ProductFolderSection`
- wire up `DirectoryService` throughout app
- improve inventory loading errors with retry button
- handle various exceptions in `InventoryService`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875aef79ea88327bc74aaa8deaf714c