### PR TITLE
Enable auto SSO for CRM using Google Identity

### DIFF
--- a/crm/login.php
+++ b/crm/login.php
@@ -1,16 +1,16 @@
 <?php
 require_once 'includes/auth_config.php';
 
-// Generate Google OAuth URL with domain restriction
-$oauth_params = array(
+// Generate OAuth parameters for GIS code flow with OpenID Connect
+$oauth_params = [
     'client_id' => GOOGLE_CLIENT_ID,
     'redirect_uri' => GOOGLE_REDIRECT_URI,
     'response_type' => 'code',
-    'scope' => 'email profile',
+    'scope' => 'openid email profile',
     'access_type' => 'offline',
     'hd' => 'theangelstones.com',
     'prompt' => 'select_account consent'
-);
+];
 
 $google_login_url = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query($oauth_params);
 ?>
@@ -91,7 +91,7 @@ $google_login_url = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build
                     <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
                 <?php endif; ?>
 
-                <a href="<?php echo htmlspecialchars($google_login_url); ?>" class="btn-google">
+                <a href="<?php echo htmlspecialchars($google_login_url); ?>" class="btn-google" id="googleBtn" style="display:none;">
                     <img src="../images/Google__G__logo.svg" alt="Google Logo">
                     Sign in with Google
                 </a>
@@ -100,5 +100,34 @@ $google_login_url = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build
         </div>
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script>
+        const codeClient = google.accounts.oauth2.initCodeClient({
+            client_id: '<?php echo GOOGLE_CLIENT_ID; ?>',
+            scope: 'openid email profile',
+            redirect_uri: '<?php echo GOOGLE_REDIRECT_URI; ?>',
+            ux_mode: 'redirect',
+            hd: 'theangelstones.com'
+        });
+
+        function startOAuth() {
+            codeClient.requestCode();
+        }
+
+        google.accounts.id.initialize({
+            client_id: '<?php echo GOOGLE_CLIENT_ID; ?>',
+            auto_select: true,
+            ux_mode: 'redirect',
+            callback: startOAuth,
+            hd: 'theangelstones.com'
+        });
+
+        google.accounts.id.prompt((notification) => {
+            if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+                document.getElementById('googleBtn').style.display = 'flex';
+                document.getElementById('googleBtn').addEventListener('click', startOAuth);
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update login page to use Google Identity Services auto select
- add openid scope and decode returned id token in callback
- validate email domain against allowed domains

## Testing
- `php -l crm/login.php`
- `php -l crm/auth_callback.php`
- `npm install`
- `npx playwright test` *(fails: Download failed: server returned code 403 body 'Domain forbidden'. URL: https://cdn.playwright.dev/...)*

------
https://chatgpt.com/codex/tasks/task_e_68778ecacd50832795934eb0cd1b8350