### PR TITLE
Add Provider-based cart state

### DIFF
--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -13,6 +13,7 @@ import 'screens/inventory_screen.dart';
 import 'screens/contact_screen.dart';
 import 'theme/app_theme.dart';
 import 'widgets/cart_icon.dart';
+import 'navigation/app_router.dart';
 
 void main() async {
   // Ensure Flutter is initialized
@@ -122,6 +123,7 @@ class MyApp extends StatelessWidget {
           type: BottomNavigationBarType.fixed,
         ),
       ),
+      onGenerateRoute: AppRouter.generateRoute,
       home: const MainNavigation(),
     );
   }
@@ -300,15 +302,7 @@ class _MainNavigationState extends State<MainNavigation> {
         actions: [
           CartIcon(
             onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: const Text('Cart coming soon'),
-                  behavior: SnackBarBehavior.floating,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-              );
+              Navigator.pushNamed(context, AppRoutePaths.cart);
             },
           ),
           IconButton(
@@ -458,15 +452,7 @@ class _MainNavigationState extends State<MainNavigation> {
         actions: [
           CartIcon(
             onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: const Text('Cart coming soon'),
-                  behavior: SnackBarBehavior.floating,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-              );
+              Navigator.pushNamed(context, AppRoutePaths.cart);
             },
           ),
           IconButton(

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -5,11 +5,14 @@ import 'services/api_service.dart';
 import 'services/storage_service.dart';
 import 'services/inventory_service.dart';
 import 'services/directory_service.dart';
+import 'package:provider/provider.dart';
+import 'state/cart_state.dart';
 import 'screens/home_screen.dart';
 import 'screens/colors_screen.dart';
 import 'screens/inventory_screen.dart';
 import 'screens/contact_screen.dart';
 import 'theme/app_theme.dart';
+import 'widgets/cart_icon.dart';
 
 void main() async {
   // Ensure Flutter is initialized
@@ -45,7 +48,12 @@ void main() async {
     // Continue with app startup anyway
   }
   
-  runApp(const MyApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => CartState(),
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -290,9 +298,7 @@ class _MainNavigationState extends State<MainNavigation> {
           ],
         ),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.shopping_cart_outlined),
-            tooltip: 'Cart',
+          CartIcon(
             onPressed: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
@@ -450,9 +456,7 @@ class _MainNavigationState extends State<MainNavigation> {
           ],
         ),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.shopping_cart_outlined),
-            tooltip: 'Cart',
+          CartIcon(
             onPressed: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(

--- a/mobile_app/lib/navigation/app_router.dart
+++ b/mobile_app/lib/navigation/app_router.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import '../models/product.dart';
+import '../screens/design_gallery_screen.dart';
+import '../screens/product_detail_screen.dart';
+import '../services/api_service.dart';
+import '../screens/cart_screen.dart';
+
+class DesignGalleryArgs {
+  final String categoryId;
+  final String title;
+  final ApiService apiService;
+  const DesignGalleryArgs({
+    required this.categoryId,
+    required this.title,
+    required this.apiService,
+  });
+}
+
+class AppRoutePaths {
+  static const String productDetail = '/product';
+  static const String designGallery = '/gallery';
+  static const String cart = '/cart';
+}
+
+class AppRouter {
+  static Route<dynamic>? generateRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case AppRoutePaths.productDetail:
+        final product = settings.arguments as Product?;
+        if (product != null) {
+          return MaterialPageRoute(
+            builder: (_) => ProductDetailScreen(product: product),
+          );
+        }
+        break;
+      case AppRoutePaths.designGallery:
+        final args = settings.arguments as DesignGalleryArgs?;
+        if (args != null) {
+          return MaterialPageRoute(
+            builder: (_) => DesignGalleryScreen(
+              categoryId: args.categoryId,
+              title: args.title,
+              apiService: args.apiService,
+            ),
+          );
+        }
+        break;
+      case AppRoutePaths.cart:
+        return MaterialPageRoute(builder: (_) => const CartScreen());
+    }
+    return null;
+  }
+}

--- a/mobile_app/lib/screens/cart_screen.dart
+++ b/mobile_app/lib/screens/cart_screen.dart
@@ -8,9 +8,9 @@ class CartScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Cart')),
       body: Center(
-        child: const Semantics(
+        child: Semantics(
           label: 'Cart is currently empty',
-          child: Text('Cart items will appear here'),
+          child: const Text('Cart items will appear here'),
         ),
       ),
     );

--- a/mobile_app/lib/screens/cart_screen.dart
+++ b/mobile_app/lib/screens/cart_screen.dart
@@ -7,8 +7,8 @@ class CartScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Cart')),
-      body: const Center(
-        child: Semantics(
+      body: Center(
+        child: const Semantics(
           label: 'Cart is currently empty',
           child: Text('Cart items will appear here'),
         ),

--- a/mobile_app/lib/screens/cart_screen.dart
+++ b/mobile_app/lib/screens/cart_screen.dart
@@ -7,7 +7,12 @@ class CartScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Cart')),
-      body: const Center(child: Text('Cart items will appear here')),
+      body: const Center(
+        child: Semantics(
+          label: 'Cart is currently empty',
+          child: Text('Cart items will appear here'),
+        ),
+      ),
     );
   }
 }

--- a/mobile_app/lib/screens/design_gallery_screen.dart
+++ b/mobile_app/lib/screens/design_gallery_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
 import '../widgets/full_screen_image.dart';
+import '../utils/error_utils.dart';
 
 class DesignGalleryScreen extends StatelessWidget {
   final String categoryId;
@@ -20,7 +21,10 @@ class DesignGalleryScreen extends StatelessWidget {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           } else if (snapshot.hasError) {
-            return Center(child: Text('Error: ${snapshot.error}'));
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              showErrorSnackBar(context, 'Failed to load designs');
+            });
+            return const Center(child: Text('Unable to load designs'));
           } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
             return const Center(child: Text('No designs found'));
           }
@@ -52,10 +56,13 @@ class DesignGalleryScreen extends StatelessWidget {
                 },
                 child: Hero(
                   tag: 'image_$index',
-                  child: Image.network(
-                    url,
-                    fit: BoxFit.cover,
-                    errorBuilder: (context, error, stack) => const Icon(Icons.broken_image),
+                  child: Semantics(
+                    label: 'Design image',
+                    child: Image.network(
+                      url,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stack) => const Icon(Icons.broken_image),
+                    ),
                   ),
                 ),
               );

--- a/mobile_app/lib/screens/inventory_screen.dart
+++ b/mobile_app/lib/screens/inventory_screen.dart
@@ -103,7 +103,10 @@ class _InventoryScreenState extends State<InventoryScreen> {
           child: Column(
             children: [
               // Search bar
-              TextField(
+              Semantics(
+                label: 'Search inventory',
+                textField: true,
+                child: TextField(
                 controller: _searchController,
                 focusNode: _searchFocusNode,
                 decoration: InputDecoration(
@@ -131,6 +134,7 @@ class _InventoryScreenState extends State<InventoryScreen> {
                 onSubmitted: (_) {
                   _searchFocusNode.unfocus();
                 },
+              ),
               ),
               const SizedBox(height: 8),
               // Filter chips

--- a/mobile_app/lib/screens/product_detail_screen.dart
+++ b/mobile_app/lib/screens/product_detail_screen.dart
@@ -20,7 +20,14 @@ class ProductDetailScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Image.network(product.imageUrl, height: 200, fit: BoxFit.cover),
+            Semantics(
+              label: product.name,
+              child: Image.network(
+                product.imageUrl,
+                height: 200,
+                fit: BoxFit.cover,
+              ),
+            ),
             const SizedBox(height: 16),
           Text(product.name, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),

--- a/mobile_app/lib/screens/product_detail_screen.dart
+++ b/mobile_app/lib/screens/product_detail_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../models/product.dart';
+import '../state/cart_state.dart';
 
 class ProductDetailScreen extends StatelessWidget {
   final Product product;
@@ -20,9 +22,19 @@ class ProductDetailScreen extends StatelessWidget {
           children: [
             Image.network(product.imageUrl, height: 200, fit: BoxFit.cover),
             const SizedBox(height: 16),
-            Text(product.name, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-            const SizedBox(height: 8),
-            Text(product.description),
+          Text(product.name, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          Text(product.description),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              context.read<CartState>().addProduct(product);
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('${product.name} added to cart')),
+              );
+            },
+            child: const Text('Add to Cart'),
+          ),
           ],
         ),
       ),

--- a/mobile_app/lib/state/cart_state.dart
+++ b/mobile_app/lib/state/cart_state.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../models/cart_item.dart';
+import '../models/product.dart';
+
+class CartState extends ChangeNotifier {
+  final List<CartItem> _items = [];
+
+  List<CartItem> get items => List.unmodifiable(_items);
+
+  int get count => _items.fold(0, (sum, item) => sum + item.quantity);
+
+  void addProduct(Product product) {
+    final index = _items.indexWhere((e) => e.product.id == product.id);
+    if (index >= 0) {
+      _items[index].quantity++;
+    } else {
+      _items.add(CartItem(product: product));
+    }
+    notifyListeners();
+  }
+
+  void removeProduct(Product product) {
+    _items.removeWhere((e) => e.product.id == product.id);
+    notifyListeners();
+  }
+
+  void clear() {
+    _items.clear();
+    notifyListeners();
+  }
+}

--- a/mobile_app/lib/utils/error_utils.dart
+++ b/mobile_app/lib/utils/error_utils.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+void showErrorSnackBar(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text(message),
+      backgroundColor: Colors.red,
+      behavior: SnackBarBehavior.floating,
+    ),
+  );
+}

--- a/mobile_app/lib/widgets/cart_icon.dart
+++ b/mobile_app/lib/widgets/cart_icon.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../state/cart_state.dart';
+
+class CartIcon extends StatelessWidget {
+  final VoidCallback onPressed;
+  const CartIcon({super.key, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final count = context.watch<CartState>().count;
+    return Stack(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.shopping_cart_outlined),
+          tooltip: 'Cart',
+          onPressed: onPressed,
+        ),
+        if (count > 0)
+          Positioned(
+            right: 4,
+            top: 4,
+            child: Container(
+              padding: const EdgeInsets.all(2),
+              decoration: const BoxDecoration(
+                color: Colors.red,
+                shape: BoxShape.circle,
+              ),
+              constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
+              child: Text(
+                '$count',
+                style: const TextStyle(color: Colors.white, fontSize: 10),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/mobile_app/lib/widgets/cart_icon.dart
+++ b/mobile_app/lib/widgets/cart_icon.dart
@@ -11,10 +11,13 @@ class CartIcon extends StatelessWidget {
     final count = context.watch<CartState>().count;
     return Stack(
       children: [
-        IconButton(
-          icon: const Icon(Icons.shopping_cart_outlined),
-          tooltip: 'Cart',
-          onPressed: onPressed,
+        Semantics(
+          label: 'Shopping cart, $count items',
+          child: IconButton(
+            icon: const Icon(Icons.shopping_cart_outlined),
+            tooltip: 'Cart',
+            onPressed: onPressed,
+          ),
         ),
         if (count > 0)
           Positioned(

--- a/mobile_app/lib/widgets/product_card.dart
+++ b/mobile_app/lib/widgets/product_card.dart
@@ -12,10 +12,13 @@ class ProductCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Expanded(
-            child: Image.network(
-              product.imageUrl,
-              fit: BoxFit.cover,
-              errorBuilder: (context, error, stackTrace) => const Icon(Icons.broken_image),
+            child: Semantics(
+              label: product.name,
+              child: Image.network(
+                product.imageUrl,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) => const Icon(Icons.broken_image),
+              ),
             ),
           ),
           Padding(

--- a/mobile_app/lib/widgets/product_folder_section.dart
+++ b/mobile_app/lib/widgets/product_folder_section.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import '../models/product.dart';
-import '../screens/design_gallery_screen.dart';
 import '../services/api_service.dart';
 import '../services/directory_service.dart';
+import '../navigation/app_router.dart';
+import '../utils/error_utils.dart';
 
 class ProductFolderSection extends StatelessWidget {
   final String title;
@@ -32,7 +33,10 @@ class ProductFolderSection extends StatelessWidget {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(child: CircularProgressIndicator());
               } else if (snapshot.hasError) {
-                return Text('Error: ${snapshot.error}');
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  showErrorSnackBar(context, 'Failed to load categories');
+                });
+                return const Text('Failed to load categories');
               } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
                 return const Text('No items found');
               }
@@ -49,14 +53,13 @@ class ProductFolderSection extends StatelessWidget {
                   final product = categories[index];
                   return GestureDetector(
                     onTap: () {
-                      Navigator.push(
+                      Navigator.pushNamed(
                         context,
-                        MaterialPageRoute(
-                          builder: (_) => DesignGalleryScreen(
-                            categoryId: product.id,
-                            title: product.name,
-                            apiService: apiService,
-                          ),
+                        AppRoutePaths.designGallery,
+                        arguments: DesignGalleryArgs(
+                          categoryId: product.id,
+                          title: product.name,
+                          apiService: apiService,
                         ),
                       );
                     },

--- a/mobile_app/lib/widgets/product_section.dart
+++ b/mobile_app/lib/widgets/product_section.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import '../models/product.dart';
-import '../screens/product_detail_screen.dart';
 import 'product_card.dart';
+import '../navigation/app_router.dart';
+import '../utils/error_utils.dart';
 
 class ProductSection extends StatelessWidget {
   final String title;
@@ -24,7 +25,10 @@ class ProductSection extends StatelessWidget {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(child: CircularProgressIndicator());
               } else if (snapshot.hasError) {
-                return Text('Error: ${snapshot.error}');
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  showErrorSnackBar(context, 'Failed to load products');
+                });
+                return const Text('Failed to load products');
               } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
                 return const Text('No items found');
               }
@@ -41,11 +45,10 @@ class ProductSection extends StatelessWidget {
                   final product = products[index];
                   return GestureDetector(
                     onTap: () {
-                      Navigator.push(
+                      Navigator.pushNamed(
                         context,
-                        MaterialPageRoute(
-                          builder: (_) => ProductDetailScreen(product: product),
-                        ),
+                        AppRoutePaths.productDetail,
+                        arguments: product,
                       );
                     },
                     child: ProductCard(product: product),

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   url_launcher: ^6.1.7
   intl: ^0.20.2
   google_fonts: ^6.1.0
+  provider: ^6.1.1
   flutter_launcher_icons: ^0.14.4
   flutter_native_splash: ^2.3.10
   flutter_pdfview: ^1.3.2


### PR DESCRIPTION
## Summary
- add `provider` package
- implement `CartState` for tracking cart items
- show a `CartIcon` badge in main app bar
- allow adding products to the cart from product details

## Testing
- `npx playwright test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d0130cdfc8327a316692e19a6b82f