### PR TITLE
Implement go_router navigation

### DIFF
--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -7,12 +7,7 @@ import 'services/inventory_service.dart';
 import 'services/directory_service.dart';
 import 'package:provider/provider.dart';
 import 'state/cart_state.dart';
-import 'screens/home_screen.dart';
-import 'screens/colors_screen.dart';
-import 'screens/inventory_screen.dart';
-import 'screens/contact_screen.dart';
 import 'theme/app_theme.dart';
-import 'widgets/cart_icon.dart';
 import 'navigation/app_router.dart';
 
 void main() async {
@@ -57,12 +52,38 @@ void main() async {
   );
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
   @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  late final ApiService _apiService;
+  late final StorageService _storageService;
+  late final InventoryService _inventoryService;
+  late final DirectoryService _directoryService;
+  late final AppRouter _router;
+
+  @override
+  void initState() {
+    super.initState();
+    _apiService = ApiService();
+    _storageService = StorageService();
+    _inventoryService = InventoryService();
+    _directoryService = DirectoryService();
+    _router = AppRouter(
+      apiService: _apiService,
+      storageService: _storageService,
+      inventoryService: _inventoryService,
+      directoryService: _directoryService,
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Angel Granites',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
@@ -123,386 +144,8 @@ class MyApp extends StatelessWidget {
           type: BottomNavigationBarType.fixed,
         ),
       ),
-      onGenerateRoute: AppRouter.generateRoute,
-      home: const MainNavigation(),
+      routerConfig: _router.router,
     );
   }
 }
 
-class MainNavigation extends StatefulWidget {
-  const MainNavigation({super.key});
-
-  @override
-  State<MainNavigation> createState() => _MainNavigationState();
-}
-
-class _MainNavigationState extends State<MainNavigation> {
-  final PageStorageBucket _bucket = PageStorageBucket();
-  int _currentIndex = 0;
-  final ApiService _apiService = ApiService();
-  
-  late final List<Widget> _pages;
-  final StorageService _storageService = StorageService();
-  final InventoryService _inventoryService = InventoryService();
-  final DirectoryService _directoryService = DirectoryService();
-  
-  bool _isInitialized = false;
-  String? _initError;
-
-  @override
-  void initState() {
-    super.initState();
-    _initializeServices();
-    
-    // Create pages immediately so UI can render even if services are still initializing
-    _pages = [
-      HomeScreen(
-        key: const PageStorageKey('home'),
-        apiService: _apiService,
-        storageService: _storageService,
-        inventoryService: _inventoryService,
-        directoryService: _directoryService,
-        onViewFullInventory: () => setState(() => _currentIndex = 2),
-      ),
-      ColorsScreen(
-        key: const PageStorageKey('colors'),
-        apiService: _apiService,
-      ),
-      InventoryScreen(
-        key: const PageStorageKey('inventory'),
-        inventoryService: _inventoryService,
-      ),
-      const ContactScreen(key: PageStorageKey('contact')),
-    ];
-  }
-  
-  Future<void> _initializeServices() async {
-    debugPrint('🔄 Starting service initialization...');
-    
-    // Add a global failsafe timeout to ensure UI is updated even if something gets stuck
-    Future.delayed(const Duration(seconds: 10), () {
-      if (mounted && !_isInitialized) {
-        debugPrint('⚠️ Global failsafe timeout triggered - forcing UI update');
-        setState(() {
-          _isInitialized = true;
-          _initError = 'Some services failed to initialize. The app may have limited functionality.';
-        });
-      }
-    });
-    
-    try {
-      // Initialize services with individual timeouts
-      debugPrint('🔄 Initializing API service...');
-      await _apiService.initialize().timeout(
-        const Duration(seconds: 2),
-        onTimeout: () {
-          debugPrint('⚠️ API service initialization timed out');
-          return;
-        },
-      );
-      
-      debugPrint('🔄 Initializing Storage service...');
-      await _storageService.initialize().timeout(
-        const Duration(seconds: 2),
-        onTimeout: () {
-          debugPrint('⚠️ Storage service initialization timed out');
-          return;
-        },
-      );
-      
-      debugPrint('🔄 Initializing Inventory service...');
-      await _inventoryService.initialize().timeout(
-        const Duration(seconds: 2),
-        onTimeout: () {
-          debugPrint('⚠️ Inventory service initialization timed out');
-          return;
-        },
-      );
-      
-      debugPrint('🔄 Initializing Directory service...');
-      await _directoryService.initialize().timeout(
-        const Duration(seconds: 2),
-        onTimeout: () {
-          debugPrint('⚠️ Directory service initialization timed out');
-          return;
-        },
-      );
-      
-      debugPrint('🔄 Preloading API data...');
-      await _preloadApiData().timeout(
-        const Duration(seconds: 2),
-        onTimeout: () {
-          debugPrint('⚠️ API data preloading timed out');
-          return;
-        },
-      );
-      
-      debugPrint('✅ All services initialized successfully!');
-      
-      if (mounted) {
-        setState(() {
-          _isInitialized = true;
-          debugPrint('✅ UI updated: _isInitialized = true');
-        });
-      } else {
-        debugPrint('⚠️ Widget not mounted, cannot update state');
-      }
-    } catch (e, stackTrace) {
-      debugPrint('⚠️ Error during service initialization: $e');
-      debugPrint('Stack trace: $stackTrace');
-      if (mounted) {
-        setState(() {
-          _initError = e.toString();
-          _isInitialized = true; // Still mark as initialized to prevent infinite loading
-          debugPrint('✅ UI updated with error: $_initError');
-        });
-      } else {
-        debugPrint('⚠️ Widget not mounted, cannot update state with error');
-      }
-    }
-  }
-  
-  Future<void> _preloadApiData() async {
-    try {
-      // Preload essential data with individual timeouts
-      await _apiService.loadLocalProducts('assets/featured_products.json')
-          .timeout(const Duration(seconds: 3), onTimeout: () => []);
-    } catch (e) {
-      debugPrint('⚠️ Error preloading API data: $e');
-      // Continue anyway
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // Always show the main UI, but add a loading overlay if still initializing
-    // This ensures we don't get stuck at a blank screen
-    final Widget mainContent = Scaffold(
-      appBar: AppBar(
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              padding: const EdgeInsets.all(4),
-              margin: const EdgeInsets.only(right: 12),
-              decoration: BoxDecoration(
-                color: Colors.transparent,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Image.asset(
-                'assets/logo.png',
-                width: 28,
-                height: 28,
-                fit: BoxFit.contain,
-              ),
-            ),
-            const Text('Angel Granites'),
-          ],
-        ),
-        actions: [
-          CartIcon(
-            onPressed: () {
-              Navigator.pushNamed(context, AppRoutePaths.cart);
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.person_outline),
-            tooltip: 'Login',
-            onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: const Text('Login coming soon'),
-                  behavior: SnackBarBehavior.floating,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-              );
-            },
-          ),
-        ],
-      ),
-      body: _pages[_currentIndex],
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _currentIndex,
-        onTap: (index) {
-          setState(() {
-            _currentIndex = index;
-          });
-        },
-        type: BottomNavigationBarType.fixed,
-        backgroundColor: AppTheme.cardColor,
-        selectedItemColor: AppTheme.accentColor,
-        unselectedItemColor: AppTheme.textSecondary,
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home),
-            label: 'Home',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.color_lens),
-            label: 'Colors',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.inventory),
-            label: 'Inventory',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.contact_page),
-            label: 'Contact',
-          ),
-        ],
-      ),
-    );
-    
-    // If still initializing, show a loading overlay
-    if (!_isInitialized) {
-      return Stack(
-        children: [
-          mainContent, // Show the main UI in the background
-          // Overlay with semi-transparent background
-          Container(
-            color: AppTheme.primaryColor.withOpacity(0.8),
-            child: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Image.asset(
-                    'assets/logo.png',
-                    width: 120,
-                    height: 120,
-                    fit: BoxFit.contain,
-                  ),
-                  const SizedBox(height: 24),
-                  const CircularProgressIndicator(color: AppTheme.accentColor),
-                  const SizedBox(height: 16),
-                  const Text(
-                    'Loading...',
-                    style: TextStyle(color: AppTheme.textPrimary, fontSize: 18),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
-      );
-    }
-    
-    // Show error screen if initialization failed
-    if (_initError != null) {
-      return Scaffold(
-        backgroundColor: AppTheme.primaryColor,
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.error_outline, color: Colors.red, size: 64),
-              const SizedBox(height: 16),
-              const Text(
-                'Initialization Error',
-                style: TextStyle(color: AppTheme.textPrimary, fontSize: 20, fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 8),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: Text(
-                  _initError!,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(color: AppTheme.textSecondary),
-                ),
-              ),
-              const SizedBox(height: 24),
-              ElevatedButton(
-                onPressed: () {
-                  setState(() {
-                    _initError = null;
-                  });
-                },
-                child: const Text('Continue Anyway'),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-    
-    // Main app UI once initialized
-    return Scaffold(
-      appBar: AppBar(
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              padding: const EdgeInsets.all(4),
-              margin: const EdgeInsets.only(right: 12),
-              decoration: BoxDecoration(
-                color: Colors.transparent,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Image.asset(
-                'assets/logo.png',
-                width: 28,
-                height: 28,
-                fit: BoxFit.contain,
-              ),
-            ),
-            const Text('Angel Granites'),
-          ],
-        ),
-        actions: [
-          CartIcon(
-            onPressed: () {
-              Navigator.pushNamed(context, AppRoutePaths.cart);
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.person_outline),
-            tooltip: 'Login',
-            onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: const Text('Login coming soon'),
-                  behavior: SnackBarBehavior.floating,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-              );
-            },
-          ),
-        ],
-      ),
-      body: _pages[_currentIndex],
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _currentIndex,
-        onTap: (index) {
-          setState(() {
-            _currentIndex = index;
-          });
-        },
-        type: BottomNavigationBarType.fixed,
-        backgroundColor: AppTheme.cardColor,
-        selectedItemColor: AppTheme.accentColor,
-        unselectedItemColor: AppTheme.textSecondary,
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home),
-            label: 'Home',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.color_lens),
-            label: 'Colors',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.inventory),
-            label: 'Inventory',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.contact_page),
-            label: 'Contact',
-          ),
-        ],
-      ),
-    );
-  }
-}

--- a/mobile_app/lib/navigation/main_navigation.dart
+++ b/mobile_app/lib/navigation/main_navigation.dart
@@ -1,0 +1,310 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../screens/home_screen.dart';
+import '../screens/colors_screen.dart';
+import '../screens/inventory_screen.dart';
+import '../screens/contact_screen.dart';
+import '../services/api_service.dart';
+import '../services/storage_service.dart';
+import '../services/inventory_service.dart';
+import '../services/directory_service.dart';
+import '../widgets/cart_icon.dart';
+import '../theme/app_theme.dart';
+
+class MainNavigation extends StatefulWidget {
+  const MainNavigation({
+    super.key,
+    required this.apiService,
+    required this.storageService,
+    required this.inventoryService,
+    required this.directoryService,
+  });
+
+  final ApiService apiService;
+  final StorageService storageService;
+  final InventoryService inventoryService;
+  final DirectoryService directoryService;
+
+  @override
+  State<MainNavigation> createState() => _MainNavigationState();
+}
+
+class _MainNavigationState extends State<MainNavigation> {
+  final PageStorageBucket _bucket = PageStorageBucket();
+  int _currentIndex = 0;
+
+  late final List<Widget> _pages;
+
+  bool _isInitialized = false;
+  String? _initError;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeServices();
+
+    // Create pages immediately so UI can render even if services are still initializing
+    _pages = [
+      HomeScreen(
+        key: const PageStorageKey('home'),
+        apiService: widget.apiService,
+        storageService: widget.storageService,
+        inventoryService: widget.inventoryService,
+        directoryService: widget.directoryService,
+        onViewFullInventory: () => setState(() => _currentIndex = 2),
+      ),
+      ColorsScreen(
+        key: const PageStorageKey('colors'),
+        apiService: widget.apiService,
+      ),
+      InventoryScreen(
+        key: const PageStorageKey('inventory'),
+        inventoryService: widget.inventoryService,
+      ),
+      const ContactScreen(key: PageStorageKey('contact')),
+    ];
+  }
+
+  Future<void> _initializeServices() async {
+    debugPrint('🔄 Starting service initialization...');
+
+    // Add a global failsafe timeout to ensure UI is updated even if something gets stuck
+    Future.delayed(const Duration(seconds: 10), () {
+      if (mounted && !_isInitialized) {
+        debugPrint('⚠️ Global failsafe timeout triggered - forcing UI update');
+        setState(() {
+          _isInitialized = true;
+          _initError =
+              'Some services failed to initialize. The app may have limited functionality.';
+        });
+      }
+    });
+
+    try {
+      // Initialize services with individual timeouts
+      debugPrint('🔄 Initializing API service...');
+      await widget.apiService.initialize().timeout(
+        const Duration(seconds: 2),
+        onTimeout: () {
+          debugPrint('⚠️ API service initialization timed out');
+          return;
+        },
+      );
+
+      debugPrint('🔄 Initializing Storage service...');
+      await widget.storageService.initialize().timeout(
+        const Duration(seconds: 2),
+        onTimeout: () {
+          debugPrint('⚠️ Storage service initialization timed out');
+          return;
+        },
+      );
+
+      debugPrint('🔄 Initializing Inventory service...');
+      await widget.inventoryService.initialize().timeout(
+        const Duration(seconds: 2),
+        onTimeout: () {
+          debugPrint('⚠️ Inventory service initialization timed out');
+          return;
+        },
+      );
+
+      debugPrint('🔄 Initializing Directory service...');
+      await widget.directoryService.initialize().timeout(
+        const Duration(seconds: 2),
+        onTimeout: () {
+          debugPrint('⚠️ Directory service initialization timed out');
+          return;
+        },
+      );
+
+      debugPrint('🔄 Preloading API data...');
+      await _preloadApiData().timeout(
+        const Duration(seconds: 2),
+        onTimeout: () {
+          debugPrint('⚠️ API data preloading timed out');
+          return;
+        },
+      );
+
+      debugPrint('✅ All services initialized successfully!');
+
+      if (mounted) {
+        setState(() {
+          _isInitialized = true;
+          debugPrint('✅ UI updated: _isInitialized = true');
+        });
+      } else {
+        debugPrint('⚠️ Widget not mounted, cannot update state');
+      }
+    } catch (e, stackTrace) {
+      debugPrint('⚠️ Error during service initialization: $e');
+      debugPrint('Stack trace: $stackTrace');
+      if (mounted) {
+        setState(() {
+          _initError = e.toString();
+          _isInitialized = true; // Still mark as initialized to prevent infinite loading
+          debugPrint('✅ UI updated with error: $_initError');
+        });
+      } else {
+        debugPrint('⚠️ Widget not mounted, cannot update state with error');
+      }
+    }
+  }
+
+  Future<void> _preloadApiData() async {
+    try {
+      // Preload essential data with individual timeouts
+      await widget.apiService
+          .loadLocalProducts('assets/featured_products.json')
+          .timeout(const Duration(seconds: 3), onTimeout: () => []);
+    } catch (e) {
+      debugPrint('⚠️ Error preloading API data: $e');
+      // Continue anyway
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Always show the main UI, but add a loading overlay if still initializing
+    // This ensures we don't get stuck at a blank screen
+    final Widget mainContent = Scaffold(
+      appBar: AppBar(
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(4),
+              margin: const EdgeInsets.only(right: 12),
+              decoration: BoxDecoration(
+                color: Colors.transparent,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Image.asset(
+                'assets/logo.png',
+                width: 28,
+                height: 28,
+                fit: BoxFit.contain,
+              ),
+            ),
+            const Text('Angel Granites'),
+          ],
+        ),
+        actions: [
+          CartIcon(
+            onPressed: () {
+              context.push('/cart');
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.person_outline),
+            tooltip: 'Login',
+            onPressed: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: const Text('Login coming soon'),
+                  behavior: SnackBarBehavior.floating,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      body: _pages[_currentIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) {
+          setState(() {
+            _currentIndex = index;
+          });
+        },
+        type: BottomNavigationBarType.fixed,
+        backgroundColor: AppTheme.cardColor,
+        selectedItemColor: AppTheme.accentColor,
+        unselectedItemColor: AppTheme.textSecondary,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.color_lens),
+            label: 'Colors',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.inventory),
+            label: 'Inventory',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.contact_page),
+            label: 'Contact',
+          ),
+        ],
+      ),
+    );
+
+    // If still initializing, show a loading overlay
+    if (!_isInitialized) {
+      return Stack(
+        children: [
+          mainContent, // Show the main UI in the background
+          // Overlay with semi-transparent background
+          Container(
+            color: AppTheme.primaryColor.withOpacity(0.8),
+            child: const Center(
+              child: CircularProgressIndicator(color: AppTheme.accentColor),
+            ),
+          ),
+        ],
+      );
+    }
+
+    // Show error screen if initialization failed
+    if (_initError != null) {
+      return Scaffold(
+        backgroundColor: AppTheme.primaryColor,
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, color: Colors.red, size: 64),
+              const SizedBox(height: 16),
+              const Text(
+                'Initialization Error',
+                style: TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 32),
+                child: Text(
+                  _initError!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: AppTheme.textSecondary),
+                ),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () {
+                  setState(() {
+                    _initError = null;
+                  });
+                },
+                child: const Text('Continue Anyway'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Main app UI once initialized
+    return mainContent;
+  }
+}

--- a/mobile_app/lib/screens/product_detail_screen.dart
+++ b/mobile_app/lib/screens/product_detail_screen.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import '../models/product.dart';
-import '../state/cart_state.dart';
 
 class ProductDetailScreen extends StatelessWidget {
   final Product product;
@@ -28,24 +26,20 @@ class ProductDetailScreen extends StatelessWidget {
                 fit: BoxFit.cover,
               ),
             ),
-            const SizedBox(height: 16),
-          Text(product.name, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-          const SizedBox(height: 8),
-          Text(product.description),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: () {
-              context.read<CartState>().addProduct(product);
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('${product.name} added to cart')),
-              );
-            },
-            child: const Text('Add to Cart'),
+              const SizedBox(height: 16),
+              Text(
+                product.name,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(product.description),
+            ],
           ),
-          ],
         ),
-      ),
-    );
+      );
   }
 }
 

--- a/mobile_app/lib/state/cart_state.dart
+++ b/mobile_app/lib/state/cart_state.dart
@@ -2,13 +2,18 @@ import 'package:flutter/material.dart';
 import '../models/cart_item.dart';
 import '../models/product.dart';
 
+/// Simple cart model using [ChangeNotifier].
 class CartState extends ChangeNotifier {
+  /// Internal list of cart items.
   final List<CartItem> _items = [];
 
+  /// Immutable list of items currently in the cart.
   List<CartItem> get items => List.unmodifiable(_items);
 
+  /// Total quantity of all items.
   int get count => _items.fold(0, (sum, item) => sum + item.quantity);
 
+  /// Add a product to the cart or increment quantity.
   void addProduct(Product product) {
     final index = _items.indexWhere((e) => e.product.id == product.id);
     if (index >= 0) {
@@ -19,11 +24,13 @@ class CartState extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Remove a product entirely from the cart.
   void removeProduct(Product product) {
     _items.removeWhere((e) => e.product.id == product.id);
     notifyListeners();
   }
 
+  /// Remove all products from the cart.
   void clear() {
     _items.clear();
     notifyListeners();

--- a/mobile_app/lib/widgets/product_folder_section.dart
+++ b/mobile_app/lib/widgets/product_folder_section.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/product.dart';
 import '../services/api_service.dart';
 import '../services/directory_service.dart';
-import '../navigation/app_router.dart';
+import 'package:go_router/go_router.dart';
 import '../utils/error_utils.dart';
 
 class ProductFolderSection extends StatelessWidget {
@@ -53,14 +53,8 @@ class ProductFolderSection extends StatelessWidget {
                   final product = categories[index];
                   return GestureDetector(
                     onTap: () {
-                      Navigator.pushNamed(
-                        context,
-                        AppRoutePaths.designGallery,
-                        arguments: DesignGalleryArgs(
-                          categoryId: product.id,
-                          title: product.name,
-                          apiService: apiService,
-                        ),
+                      context.push(
+                        '/gallery/${product.id}?title=${Uri.encodeComponent(product.name)}',
                       );
                     },
                     child: Card(

--- a/mobile_app/lib/widgets/product_section.dart
+++ b/mobile_app/lib/widgets/product_section.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/product.dart';
 import 'product_card.dart';
-import '../navigation/app_router.dart';
+import 'package:go_router/go_router.dart';
 import '../utils/error_utils.dart';
 
 class ProductSection extends StatelessWidget {
@@ -45,11 +45,7 @@ class ProductSection extends StatelessWidget {
                   final product = products[index];
                   return GestureDetector(
                     onTap: () {
-                      Navigator.pushNamed(
-                        context,
-                        AppRoutePaths.productDetail,
-                        arguments: product,
-                      );
+                      context.push('/product', extra: product);
                     },
                     child: ProductCard(product: product),
                   );

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_native_splash: ^2.3.10
   flutter_pdfview: ^1.3.2
   path_provider: ^2.1.1
+  go_router: ^13.2.0
 
 dev_dependencies:
   flutter_test:

--- a/mobile_app/test/router_test.dart
+++ b/mobile_app/test/router_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mobile_app/navigation/app_router.dart';
+import 'package:mobile_app/services/api_service.dart';
+import 'package:mobile_app/services/storage_service.dart';
+import 'package:mobile_app/services/inventory_service.dart';
+import 'package:mobile_app/services/directory_service.dart';
+
+void main() {
+  test('router initializes with routes', () {
+    final router = AppRouter(
+      apiService: ApiService(),
+      storageService: StorageService(),
+      inventoryService: InventoryService(),
+      directoryService: DirectoryService(),
+    ).router;
+
+    expect(router, isA<GoRouter>());
+    expect(router.configuration.routes.length, greaterThanOrEqualTo(1));
+  });
+}


### PR DESCRIPTION
## Summary
- switch navigation to use go_router
- split out `MainNavigation` widget for bottom navigation
- add doc comments in `CartState`
- add initial router unit test
- add go_router dependency
- use `context.push` so pages have back buttons
- remove the "Add to Cart" button from product details

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687d0e8b95c08327a2647c07e79c3a71