### PR TITLE
Fix unmatched closing parenthesis in ProductFolderSection

### DIFF
--- a/mobile_app/lib/widgets/product_folder_section.dart
+++ b/mobile_app/lib/widgets/product_folder_section.dart
@@ -3,7 +3,6 @@ import '../models/product.dart';
 import '../services/api_service.dart';
 import '../services/directory_service.dart';
 import 'package:go_router/go_router.dart';
-import 'package:go_router/go_router.dart';
 import '../utils/error_utils.dart';
 
 class ProductFolderSection extends StatelessWidget {
@@ -335,6 +334,7 @@ class ProductFolderSection extends StatelessWidget {
           ),
         ],
       ),
+    );
     );
   }
 }


### PR DESCRIPTION
## Summary
- close the outer `Padding` widget in `ProductFolderSection`

## Testing
- `echo opens $(grep -o "(" mobile_app/lib/widgets/product_folder_section.dart | wc -l) closes $(grep -o ")" mobile_app/lib/widgets/product_folder_section.dart | wc -l)`

------
https://chatgpt.com/codex/tasks/task_e_687d54147d848327a53ee6da19ae697e