### PR TITLE
Fix parentheses mismatch in ProductFolderSection

### DIFF
--- a/mobile_app/lib/widgets/product_folder_section.dart
+++ b/mobile_app/lib/widgets/product_folder_section.dart
@@ -335,7 +335,6 @@ class ProductFolderSection extends StatelessWidget {
         ],
       ),
     );
-    );
   }
 }
 


### PR DESCRIPTION
## Summary
- fix unmatched parenthesis at end of `ProductFolderSection`

## Testing
- `npx playwright test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d5f8e43888327ac66ac6a2fd0f546