### PR TITLE
Fix closing parenthesis in product folder section

### DIFF
--- a/mobile_app/lib/widgets/product_folder_section.dart
+++ b/mobile_app/lib/widgets/product_folder_section.dart
@@ -335,6 +335,7 @@ class ProductFolderSection extends StatelessWidget {
         ],
       ),
     );
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in `ProductFolderSection`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d61b977d88327b21e69618bdbe9e1