### PR TITLE
Fix missing Material widget error from cart

### DIFF
--- a/mobile_app/lib/navigation/app_router.dart
+++ b/mobile_app/lib/navigation/app_router.dart
@@ -72,8 +72,10 @@ class AppRouter {
       ),
       GoRoute(
         path: '/inventory',
-        builder: (context, state) =>
-            InventoryScreen(inventoryService: inventoryService),
+        builder: (context, state) => Scaffold(
+          appBar: AppBar(title: const Text('Inventory')),
+          body: InventoryScreen(inventoryService: inventoryService),
+        ),
       ),
       GoRoute(
         path: '/contact',


### PR DESCRIPTION
## Summary
- wrap `/inventory` route in a `Scaffold` so InventoryScreen has a Material ancestor

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882c386f60483279043f35c873cf6ce