### PR TITLE
Fix missing Material widget error from cart

### DIFF
--- a/mobile_app/lib/navigation/app_router.dart
+++ b/mobile_app/lib/navigation/app_router.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../models/product.dart';
@@ -72,8 +73,10 @@ class AppRouter {
       ),
       GoRoute(
         path: '/inventory',
-        builder: (context, state) =>
-            InventoryScreen(inventoryService: inventoryService),
+        builder: (context, state) => Scaffold(
+          appBar: AppBar(title: const Text('Inventory')),
+          body: InventoryScreen(inventoryService: inventoryService),
+        ),
       ),
       GoRoute(
         path: '/contact',


### PR DESCRIPTION
## Summary
- import Flutter Material in `AppRouter`
- `InventoryScreen` route now returns a `Scaffold` so it has a Material ancestor

## Testing
- `npx playwright test --max-failures=1` *(fails: Navigation Bar Links check)*

------
https://chatgpt.com/codex/tasks/task_e_6882c386f60483279043f35c873cf6ce