### PR TITLE
Implement TTL-based cache refresh for mobile app

### DIFF
--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -58,7 +58,7 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   // Initialize services
   late final StorageService _storageService = StorageService();
   late final ApiService _apiService;
@@ -73,6 +73,8 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+
+    WidgetsBinding.instance.addObserver(this);
     
     // Initialize services in the correct order
     _apiService = ApiService(storageService: _storageService);
@@ -147,6 +149,21 @@ class _MyAppState extends State<MyApp> {
     } catch (e) {
       debugPrint('Error initializing saved items: $e');
     }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _apiService.clearExpiredCache();
+      _inventoryService.clearExpiredCache();
+      _storageService.clearExpiredCache();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
   }
 
   @override

--- a/mobile_app/lib/screens/home_screen.dart
+++ b/mobile_app/lib/screens/home_screen.dart
@@ -52,7 +52,8 @@ class _HomeScreenState extends State<HomeScreen> {
       // Fetch featured products dynamically from server with force refresh
       _futureFeatured = widget.apiService.fetchFeaturedProducts(forceRefresh: true);
       // Fetch inventory summary from API
-      _futureInventorySummary = widget.inventoryService.fetchInventory(pageSize: 3);
+      _futureInventorySummary =
+          widget.inventoryService.fetchInventory(pageSize: 3, forceRefresh: true);
       // Refresh specials
       _futureSpecials = widget.apiService.loadLocalProducts('assets/specials.json');
     });

--- a/mobile_app/lib/screens/inventory_screen.dart
+++ b/mobile_app/lib/screens/inventory_screen.dart
@@ -92,13 +92,14 @@ class _InventoryScreenState extends State<InventoryScreen> {
     super.dispose();
   }
 
-  Future<void> _loadInventory() async {
+  Future<void> _loadInventory({bool forceRefresh = false}) async {
     setState(() {
       _futureInventory = widget.inventoryService.fetchInventory(
         pageSize: 100,
         searchQuery: _searchQuery.isNotEmpty ? _searchQuery : null,
         type: _selectedType,
         color: _selectedColor,
+        forceRefresh: forceRefresh,
       );
     });
   }
@@ -111,7 +112,7 @@ class _InventoryScreenState extends State<InventoryScreen> {
     _selectedColor = null;
     
     // Reload inventory data
-    await _loadInventory();
+    await _loadInventory(forceRefresh: true);
     
     // Refresh filter options
     _fetchFilterOptions();

--- a/mobile_app/lib/utils/cache_entry.dart
+++ b/mobile_app/lib/utils/cache_entry.dart
@@ -1,0 +1,9 @@
+class CacheEntry<T> {
+  final T data;
+  final DateTime timestamp;
+  CacheEntry(this.data) : timestamp = DateTime.now();
+
+  bool isExpired(Duration ttl) {
+    return DateTime.now().difference(timestamp) > ttl;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `CacheEntry` helper for TTL-based memory caches
- integrate TTL cache logic across `ApiService`, `InventoryService`, and `StorageService`
- refresh data on pull to refresh and clear expired cache when app resumes
- expose `forceRefresh` option for inventory retrieval and update screens
- update home and inventory screens to use new refresh parameter

## Testing
- `npx playwright test` *(fails: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6887cc738a98832795c6559c16c52630