### PR TITLE
Implement offline catalog skeleton

### DIFF
--- a/mobile_app/lib/background/sync_worker.dart
+++ b/mobile_app/lib/background/sync_worker.dart
@@ -1,0 +1,10 @@
+import '../services/offline_catalog_service.dart';
+
+class SyncWorker {
+  final OfflineCatalogService catalogService;
+  SyncWorker({required this.catalogService});
+
+  Future<void> performSync() async {
+    await catalogService.syncCatalog();
+  }
+}

--- a/mobile_app/lib/config/offline_config.dart
+++ b/mobile_app/lib/config/offline_config.dart
@@ -1,0 +1,8 @@
+class OfflineConfig {
+  OfflineConfig._();
+
+  static const String databaseName = 'offline_catalog.db';
+  static const int databaseVersion = 1;
+  static const Duration maxCacheAge = Duration(days: 7);
+  static const Duration syncInterval = Duration(hours: 6);
+}

--- a/mobile_app/lib/database/app_database.dart
+++ b/mobile_app/lib/database/app_database.dart
@@ -1,0 +1,36 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../config/offline_config.dart';
+import '../models/product.dart';
+
+class AppDatabase {
+  static Database? _db;
+
+  static Future<Database> get database async {
+    if (_db != null) return _db!;
+    _db = await _initDb();
+    return _db!;
+  }
+
+  static Future<Database> _initDb() async {
+    final documentsDir = await getApplicationDocumentsDirectory();
+    final path = join(documentsDir.path, OfflineConfig.databaseName);
+    return openDatabase(
+      path,
+      version: OfflineConfig.databaseVersion,
+      onCreate: (db, version) async {
+        await db.execute('''
+          CREATE TABLE products(
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            description TEXT,
+            imageUrl TEXT,
+            price REAL
+          )
+        ''');
+      },
+    );
+  }
+}

--- a/mobile_app/lib/database/dao/product_dao.dart
+++ b/mobile_app/lib/database/dao/product_dao.dart
@@ -1,0 +1,30 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../app_database.dart';
+import '../../models/product.dart';
+
+class ProductDao {
+  Future<void> insertProducts(List<Product> products) async {
+    final db = await AppDatabase.database;
+    final batch = db.batch();
+    for (final product in products) {
+      batch.insert(
+        'products',
+        product.toJson(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    }
+    await batch.commit(noResult: true);
+  }
+
+  Future<List<Product>> getAllProducts() async {
+    final db = await AppDatabase.database;
+    final maps = await db.query('products');
+    return maps.map((e) => Product.fromJson(e)).toList();
+  }
+
+  Future<void> clearProducts() async {
+    final db = await AppDatabase.database;
+    await db.delete('products');
+  }
+}

--- a/mobile_app/lib/models/offline_catalog.dart
+++ b/mobile_app/lib/models/offline_catalog.dart
@@ -1,0 +1,20 @@
+class OfflineCatalog {
+  final String version;
+  final DateTime lastSync;
+
+  OfflineCatalog({required this.version, required this.lastSync});
+
+  factory OfflineCatalog.fromJson(Map<String, dynamic> json) {
+    return OfflineCatalog(
+      version: json['version'] as String? ?? '1.0',
+      lastSync: DateTime.parse(json['lastSync'] as String? ?? DateTime.now().toIso8601String()),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'version': version,
+      'lastSync': lastSync.toIso8601String(),
+    };
+  }
+}

--- a/mobile_app/lib/models/sync_status.dart
+++ b/mobile_app/lib/models/sync_status.dart
@@ -1,0 +1,9 @@
+enum SyncState { idle, syncing, success, error }
+
+class SyncStatus {
+  final SyncState state;
+  final double progress;
+  final String? message;
+
+  SyncStatus({required this.state, this.progress = 0, this.message});
+}

--- a/mobile_app/lib/navigation/app_router.dart
+++ b/mobile_app/lib/navigation/app_router.dart
@@ -17,10 +17,13 @@ import '../screens/product_detail_screen.dart';
 import '../screens/saved_items_screen.dart';
 import '../screens/quote_request_screen.dart';
 import '../screens/search_screen_v2.dart';
+import '../screens/offline_catalog_screen.dart';
+import '../screens/sync_settings_screen.dart';
 import '../services/api_service.dart';
 import '../services/directory_service.dart';
 import '../services/inventory_service.dart';
 import '../services/storage_service.dart';
+import '../services/offline_catalog_service.dart';
 import 'main_navigation.dart';
 
 /// Holds all application routes using [GoRouter].
@@ -38,12 +41,15 @@ class AppRouter {
   static const String quoteRequest = 'quote-request';
   static const String inventoryItemDetails = 'inventory-item-details';
   static const String search = 'search';
+  static const String offlineCatalog = 'offline-catalog';
+  static const String syncSettings = 'sync-settings';
 
   AppRouter({
     required this.apiService,
     required this.storageService,
     required this.inventoryService,
     required this.directoryService,
+    required this.offlineCatalogService,
   });
 
   /// API helper for loading data.
@@ -54,6 +60,8 @@ class AppRouter {
 
   /// Inventory backend helper.
   final InventoryService inventoryService;
+
+  final OfflineCatalogService offlineCatalogService;
 
   /// Directory helper for fetching design counts.
   final DirectoryService directoryService;
@@ -166,6 +174,18 @@ class AppRouter {
           apiService: apiService,
           storageService: storageService,
         ),
+      ),
+      GoRoute(
+        path: '/offline-catalog',
+        name: offlineCatalog,
+        builder: (context, state) => OfflineCatalogScreen(
+          catalogService: offlineCatalogService,
+        ),
+      ),
+      GoRoute(
+        path: '/sync-settings',
+        name: syncSettings,
+        builder: (context, state) => const SyncSettingsScreen(),
       ),
     ],
   );

--- a/mobile_app/lib/screens/offline_catalog_screen.dart
+++ b/mobile_app/lib/screens/offline_catalog_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import '../models/product.dart';
+import '../services/offline_catalog_service.dart';
+import '../widgets/offline_banner.dart';
+import '../widgets/sync_progress_indicator.dart';
+
+class OfflineCatalogScreen extends StatefulWidget {
+  final OfflineCatalogService catalogService;
+  const OfflineCatalogScreen({super.key, required this.catalogService});
+
+  @override
+  State<OfflineCatalogScreen> createState() => _OfflineCatalogScreenState();
+}
+
+class _OfflineCatalogScreenState extends State<OfflineCatalogScreen> {
+  late Future<List<Product>> _productsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _productsFuture = widget.catalogService.getAllProducts();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Offline Catalog')),
+      body: Column(
+        children: [
+          OfflineBanner(connectivityService: widget.catalogService.connectivityService),
+          SyncProgressIndicator(statusStream: widget.catalogService.statusStream),
+          Expanded(
+            child: FutureBuilder<List<Product>>(
+              future: _productsFuture,
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final products = snapshot.data!;
+                if (products.isEmpty) {
+                  return const Center(child: Text('No offline data'));
+                }
+                return ListView.builder(
+                  itemCount: products.length,
+                  itemBuilder: (context, index) {
+                    final p = products[index];
+                    return ListTile(
+                      title: Text(p.name),
+                      subtitle: Text(p.description),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await widget.catalogService.syncCatalog();
+          setState(() {
+            _productsFuture = widget.catalogService.getAllProducts();
+          });
+        },
+        child: const Icon(Icons.sync),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/screens/search_screen_v2.dart
+++ b/mobile_app/lib/screens/search_screen_v2.dart
@@ -41,7 +41,6 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
   List<Product> _productResults = [];
   List<String> _colorResults = [];
   Map<String, List<InventoryItem>> _typeGroupedResults = {};
-  List<InventoryItem> _inventoryResults = [];
   
   Timer? _searchDebounce;
   
@@ -104,7 +103,6 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
         _productResults = [];
         _colorResults = [];
         _typeGroupedResults = {};
-        _inventoryResults = [];
         _hasResults = false;
       });
       return;
@@ -360,10 +358,8 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
 
       if (inventoryResults.isNotEmpty || colors.isNotEmpty || typeGroups.isNotEmpty) {
         setState(() {
-          _inventoryResults = inventoryResults;
           _colorResults = colors.toList();
           _typeGroupedResults = typeGroups;
-          _inventoryResults = inventoryResults;
         });
 
         hasAnyResults = hasAnyResults || inventoryResults.isNotEmpty;

--- a/mobile_app/lib/screens/sync_settings_screen.dart
+++ b/mobile_app/lib/screens/sync_settings_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import '../config/offline_config.dart';
+
+class SyncSettingsScreen extends StatelessWidget {
+  const SyncSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sync Settings')),
+      body: const Padding(
+        padding: EdgeInsets.all(16),
+        child: Text('Configure sync frequency and storage limits here.'),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/services/connectivity_service.dart
+++ b/mobile_app/lib/services/connectivity_service.dart
@@ -1,0 +1,17 @@
+import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class ConnectivityService {
+  final Connectivity _connectivity = Connectivity();
+
+  Stream<bool> get onConnectivityChanged async* {
+    await for (final result in _connectivity.onConnectivityChanged) {
+      yield result != ConnectivityResult.none;
+    }
+  }
+
+  Future<bool> get isOnline async {
+    final result = await _connectivity.checkConnectivity();
+    return result != ConnectivityResult.none;
+  }
+}

--- a/mobile_app/lib/services/offline_catalog_service.dart
+++ b/mobile_app/lib/services/offline_catalog_service.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import '../database/dao/product_dao.dart';
+import '../models/product.dart';
+import '../models/sync_status.dart';
+import 'api_service.dart';
+import 'connectivity_service.dart';
+
+class OfflineCatalogService {
+  final ApiService apiService;
+  final ConnectivityService connectivityService;
+  final ProductDao _productDao = ProductDao();
+
+  final StreamController<SyncStatus> _statusController =
+      StreamController.broadcast();
+
+  Stream<SyncStatus> get statusStream => _statusController.stream;
+
+  OfflineCatalogService({required this.apiService, required this.connectivityService});
+
+  Future<void> syncCatalog() async {
+    final online = await connectivityService.isOnline;
+    if (!online) {
+      _statusController.add(SyncStatus(state: SyncState.error, message: 'Offline'));
+      return;
+    }
+    _statusController.add(SyncStatus(state: SyncState.syncing, progress: 0));
+    try {
+      final directories = await apiService.getProductDirectories();
+      int count = 0;
+      for (final dir in directories) {
+        final dirName = dir.split('/').last;
+        final products = await apiService.fetchProductImagesWithCodes(dirName);
+        await _productDao.insertProducts(products);
+        count++;
+        _statusController.add(SyncStatus(
+            state: SyncState.syncing,
+            progress: count / directories.length));
+      }
+      _statusController.add(SyncStatus(state: SyncState.success, progress: 1));
+    } catch (e) {
+      _statusController.add(SyncStatus(state: SyncState.error, message: e.toString()));
+    }
+  }
+
+  Future<List<Product>> getAllProducts() {
+    return _productDao.getAllProducts();
+  }
+}

--- a/mobile_app/lib/widgets/offline_banner.dart
+++ b/mobile_app/lib/widgets/offline_banner.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import '../services/connectivity_service.dart';
+
+class OfflineBanner extends StatelessWidget {
+  final ConnectivityService connectivityService;
+  const OfflineBanner({super.key, required this.connectivityService});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<bool>(
+      stream: connectivityService.onConnectivityChanged,
+      initialData: true,
+      builder: (context, snapshot) {
+        final online = snapshot.data ?? true;
+        if (online) return const SizedBox.shrink();
+        return Container(
+          width: double.infinity,
+          color: Colors.red,
+          padding: const EdgeInsets.all(8),
+          child: const Text(
+            'Offline mode',
+            style: TextStyle(color: Colors.white),
+            textAlign: TextAlign.center,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/mobile_app/lib/widgets/sync_progress_indicator.dart
+++ b/mobile_app/lib/widgets/sync_progress_indicator.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import '../models/sync_status.dart';
+
+class SyncProgressIndicator extends StatelessWidget {
+  final Stream<SyncStatus> statusStream;
+  const SyncProgressIndicator({super.key, required this.statusStream});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<SyncStatus>(
+      stream: statusStream,
+      builder: (context, snapshot) {
+        final status = snapshot.data;
+        if (status == null || status.state == SyncState.idle) {
+          return const SizedBox.shrink();
+        }
+        if (status.state == SyncState.syncing) {
+          return LinearProgressIndicator(value: status.progress);
+        }
+        if (status.state == SyncState.error) {
+          return const Text('Sync failed', style: TextStyle(color: Colors.red));
+        }
+        return const SizedBox.shrink();
+      },
+    );
+  }
+}

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   pdfx: ^2.9.2  # Modern PDF viewer with better maintenance and features
   path_provider: ^2.1.5
   path: ^1.9.1
+  sqflite: ^2.3.2
+  connectivity_plus: ^5.0.2
 
   # Firebase packages
   firebase_storage: ^12.4.10   # ← correct

--- a/mobile_app/test/router_test.dart.bak
+++ b/mobile_app/test/router_test.dart.bak
@@ -5,6 +5,8 @@ import 'package:mobile_app/services/api_service.dart';
 import 'package:mobile_app/services/storage_service.dart';
 import 'package:mobile_app/services/inventory_service.dart';
 import 'package:mobile_app/services/directory_service.dart';
+import 'package:mobile_app/services/offline_catalog_service.dart';
+import 'package:mobile_app/services/connectivity_service.dart';
 
 void main() {
   test('router initializes with routes', () {
@@ -13,6 +15,10 @@ void main() {
       storageService: StorageService(),
       inventoryService: InventoryService(),
       directoryService: DirectoryService(),
+      offlineCatalogService: OfflineCatalogService(
+        apiService: ApiService(),
+        connectivityService: ConnectivityService(),
+      ),
     ).router;
 
     expect(router, isA<GoRouter>());


### PR DESCRIPTION
## Summary
- add new offline catalog data structures and database
- provide services and widgets for offline mode
- wire up offline routes and background sync in the Flutter app
- fix unused `_inventoryResults` field warning

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887e07b24908327b405d7443213cae7