### PR TITLE
Add push notification framework

### DIFF
--- a/mobile_app/lib/config/notification_config.dart
+++ b/mobile_app/lib/config/notification_config.dart
@@ -1,0 +1,6 @@
+class NotificationConfig {
+  static const int colorGroupThreshold = 1;
+  static const int productGroupThreshold = 1;
+  static const int inventoryGroupThreshold = 25;
+  static const Duration throttleDuration = Duration(hours: 12);
+}

--- a/mobile_app/lib/firebase/firebase_messaging_handler.dart
+++ b/mobile_app/lib/firebase/firebase_messaging_handler.dart
@@ -1,0 +1,23 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import '../services/notification_service.dart';
+import '../models/notification_payload.dart';
+
+class FirebaseMessagingHandler {
+  static Future<void> setup() async {
+    FirebaseMessaging.onBackgroundMessage(_backgroundHandler);
+    await NotificationService.instance.initialize();
+  }
+
+  static Future<void> _backgroundHandler(RemoteMessage message) async {
+    final notification = message.notification;
+    if (notification != null) {
+      NotificationService.instance.displayNotification(
+        NotificationPayload(
+          title: notification.title ?? '',
+          body: notification.body ?? '',
+          data: message.data,
+        ),
+      );
+    }
+  }
+}

--- a/mobile_app/lib/models/notification_payload.dart
+++ b/mobile_app/lib/models/notification_payload.dart
@@ -1,0 +1,13 @@
+class NotificationPayload {
+  final String title;
+  final String body;
+  final String? deepLink;
+  final Map<String, dynamic>? data;
+
+  NotificationPayload({
+    required this.title,
+    required this.body,
+    this.deepLink,
+    this.data,
+  });
+}

--- a/mobile_app/lib/models/notification_preferences.dart
+++ b/mobile_app/lib/models/notification_preferences.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class NotificationPreferences {
+  bool newColors;
+  bool newProducts;
+  bool inventoryUpdates;
+  bool specialOffers;
+  TimeOfDay? quietStart;
+  TimeOfDay? quietEnd;
+
+  NotificationPreferences({
+    this.newColors = true,
+    this.newProducts = true,
+    this.inventoryUpdates = true,
+    this.specialOffers = true,
+    this.quietStart,
+    this.quietEnd,
+  });
+}

--- a/mobile_app/lib/screens/notification_preferences_screen.dart
+++ b/mobile_app/lib/screens/notification_preferences_screen.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import '../services/notification_service.dart';
+import '../models/notification_preferences.dart';
+
+class NotificationPreferencesScreen extends StatefulWidget {
+  const NotificationPreferencesScreen({super.key});
+
+  @override
+  State<NotificationPreferencesScreen> createState() => _NotificationPreferencesScreenState();
+}
+
+class _NotificationPreferencesScreenState extends State<NotificationPreferencesScreen> {
+  final NotificationService _service = NotificationService.instance;
+
+  late NotificationPreferences _prefs;
+
+  @override
+  void initState() {
+    super.initState();
+    _prefs = _service.preferences;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notification Preferences')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          SwitchListTile(
+            title: const Text('New Colors'),
+            value: _prefs.newColors,
+            onChanged: (val) {
+              setState(() => _prefs.newColors = val);
+            },
+          ),
+          SwitchListTile(
+            title: const Text('New Products'),
+            value: _prefs.newProducts,
+            onChanged: (val) {
+              setState(() => _prefs.newProducts = val);
+            },
+          ),
+          SwitchListTile(
+            title: const Text('Inventory Updates'),
+            value: _prefs.inventoryUpdates,
+            onChanged: (val) {
+              setState(() => _prefs.inventoryUpdates = val);
+            },
+          ),
+          SwitchListTile(
+            title: const Text('Special Offers'),
+            value: _prefs.specialOffers,
+            onChanged: (val) {
+              setState(() => _prefs.specialOffers = val);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/services/notification_scheduler.dart
+++ b/mobile_app/lib/services/notification_scheduler.dart
@@ -1,0 +1,37 @@
+import "package:timezone/timezone.dart" as tz;
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import '../models/notification_payload.dart';
+
+class NotificationScheduler {
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+
+  Future<void> scheduleDaily(NotificationPayload payload, Time time) async {
+    final androidDetails = AndroidNotificationDetails(
+      'scheduled_channel',
+      'Scheduled Notifications',
+    );
+    final details = NotificationDetails(android: androidDetails);
+
+    await _plugin.zonedSchedule(
+      0,
+      payload.title,
+      payload.body,
+      _nextInstanceOf(time),
+      details,
+      androidAllowWhileIdle: true,
+      payload: payload.deepLink,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  tz.TZDateTime _nextInstanceOf(Time time) {
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduled = tz.TZDateTime(tz.local, now.year, now.month, now.day, time.hour, time.minute);
+    if (scheduled.isBefore(now)) {
+      scheduled = scheduled.add(const Duration(days: 1));
+    }
+    return scheduled;
+  }
+}

--- a/mobile_app/lib/services/notification_service.dart
+++ b/mobile_app/lib/services/notification_service.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+import '../models/notification_payload.dart';
+import '../config/notification_config.dart';
+import '../models/notification_preferences.dart';
+
+class NotificationService {
+  NotificationService._();
+  static final NotificationService instance = NotificationService._();
+
+  final FirebaseMessaging _messaging = FirebaseMessaging.instance;
+  final FlutterLocalNotificationsPlugin _localNotifications =
+      FlutterLocalNotificationsPlugin();
+
+  final Map<String, DateTime> _lastSent = {};
+  NotificationPreferences preferences = NotificationPreferences();
+
+  Future<void> initialize() async {
+    const AndroidInitializationSettings androidSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const DarwinInitializationSettings iosSettings = DarwinInitializationSettings();
+    const InitializationSettings initSettings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+    await _localNotifications.initialize(initSettings,
+        onDidReceiveNotificationResponse: (response) {
+      final payload = response.payload;
+      if (payload != null) {
+        // handle deep link if needed
+      }
+    });
+
+    await _messaging.requestPermission();
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+      final notification = message.notification;
+      if (notification != null) {
+        displayNotification(
+          NotificationPayload(
+            title: notification.title ?? '',
+            body: notification.body ?? '',
+            data: message.data,
+          ),
+        );
+      }
+    });
+  }
+
+  Future<String?> getToken() async {
+    return _messaging.getToken();
+  }
+
+  Future<void> displayNotification(NotificationPayload payload) async {
+    final now = DateTime.now();
+    final last = _lastSent[payload.title];
+    if (last != null && now.difference(last) < NotificationConfig.throttleDuration) {
+      return;
+    }
+
+    _lastSent[payload.title] = now;
+
+    const AndroidNotificationDetails androidDetails = AndroidNotificationDetails(
+      'general_channel',
+      'General Notifications',
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+    );
+    const NotificationDetails details = NotificationDetails(android: androidDetails);
+    await _localNotifications.show(0, payload.title, payload.body, details,
+        payload: payload.deepLink);
+  }
+}

--- a/mobile_app/lib/services/product_change_detector.dart
+++ b/mobile_app/lib/services/product_change_detector.dart
@@ -1,0 +1,33 @@
+import '../models/inventory_item.dart';
+import 'inventory_service.dart';
+import '../models/notification_payload.dart';
+import '../config/notification_config.dart';
+
+class ProductChangeDetector {
+  final InventoryService inventoryService;
+  List<InventoryItem> _knownInventory = [];
+
+  ProductChangeDetector({required this.inventoryService});
+
+  Future<List<NotificationPayload>> checkForUpdates() async {
+    final List<NotificationPayload> notifications = [];
+    final currentInventory = await inventoryService.fetchInventory();
+
+    final newItems = currentInventory
+        .where((item) => !_knownInventory.any((p) => p.code == item.code))
+        .toList();
+
+    if (newItems.length >= NotificationConfig.inventoryGroupThreshold) {
+      notifications.add(
+        NotificationPayload(
+          title: 'New inventory items',
+          body: 'More than ${newItems.length} new items arrived!',
+          deepLink: '/inventory',
+        ),
+      );
+    }
+
+    _knownInventory = currentInventory;
+    return notifications;
+  }
+}

--- a/mobile_app/lib/widgets/notification_permission_prompt.dart
+++ b/mobile_app/lib/widgets/notification_permission_prompt.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import '../services/notification_service.dart';
+
+class NotificationPermissionPrompt extends StatelessWidget {
+  const NotificationPermissionPrompt({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Enable Notifications'),
+      content: const Text('Stay updated with the latest products and offers.'),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('No Thanks'),
+        ),
+        ElevatedButton(
+          onPressed: () async {
+            await NotificationService.instance.initialize();
+            Navigator.of(context).pop();
+          },
+          child: const Text('Allow'),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
   firebase_analytics: ^11.6.0
   firebase_messaging: ^15.2.10
   firebase_crashlytics: ^4.3.10
+  flutter_local_notifications: ^16.2.0
+  timezone: ^0.9.2
 
   # Removed shared_preferences dependency
   collection: any


### PR DESCRIPTION
## Summary
- add notification services and models to Flutter app
- wire up Firebase messaging handler and local notification scheduler
- update Flutter dependencies for push notifications

## Testing
- `npm install`
- `npx playwright test` *(fails: Playwright browsers couldn't download)*

------
https://chatgpt.com/codex/tasks/task_e_6887e7668d7c8327bf87dcc74b7c000e