### PR TITLE
Fix lint warnings in mobile app

### DIFF
--- a/mobile_app/lib/database/app_database.dart
+++ b/mobile_app/lib/database/app_database.dart
@@ -3,7 +3,6 @@ import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../config/offline_config.dart';
-import '../models/product.dart';
 
 class AppDatabase {
   static Database? _db;

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -15,7 +15,6 @@ import 'state/saved_items_state.dart';
 import 'package:provider/provider.dart';
 import 'services/firebase_service.dart';
 import 'services/analytics_wrapper.dart';
-import 'widgets/connectivity_handler.dart';
 
 void main() async {
   // Ensure Flutter is initialized

--- a/mobile_app/lib/screens/search_screen.dart
+++ b/mobile_app/lib/screens/search_screen.dart
@@ -23,11 +23,11 @@ class SearchScreen extends StatefulWidget {
   final DirectoryService? directoryService;
 
   const SearchScreen({
-    Key? key, 
+    super.key,
     this.inventoryService,
     this.apiService,
     this.directoryService,
-  }) : super(key: key);
+  });
 
   @override
   State<SearchScreen> createState() => _SearchScreenState();
@@ -123,16 +123,6 @@ class _SearchScreenState extends State<SearchScreen> {
     }
   }
   
-  // Get the Directory service instance
-  DirectoryService _getDirectoryService() {
-    // First try to use the service passed directly to the widget
-    if (widget.directoryService != null) {
-      return widget.directoryService!;
-    }
-    
-    // If not available, create a new instance
-    return DirectoryService();
-  }
   
   Future<void> _performSearch(String query) async {
     setState(() {
@@ -390,7 +380,7 @@ class _SearchScreenState extends State<SearchScreen> {
                         debugPrint('🔍 DEBUG: Creating product with code: $productCode');
                         
                         final product = Product(
-                          id: 'dir-${dir}-$name',
+                          id: 'dir-$dir-$name',
                           name: productCode.isNotEmpty ? 'Product $productCode' : name,
                           description: 'Directory product from $dir',
                           imageUrl: '${DirectoryService.baseUrl}/$path',
@@ -898,9 +888,9 @@ class _SearchScreenState extends State<SearchScreen> {
           
           // Types section - each type gets its own expandable section
           if (_typeGroupedResults.isNotEmpty) ...
-          _typeGroupedResults.entries.map((entry) {
-            return _buildTypeSection(entry.key, entry.value);
-          }).toList(),
+            _typeGroupedResults.entries.map(
+              (entry) => _buildTypeSection(entry.key, entry.value),
+            ),
           
           // Inventory items section (items not grouped by type)
           if (_searchResults.isNotEmpty) ...[  

--- a/mobile_app/lib/screens/sync_settings_screen.dart
+++ b/mobile_app/lib/screens/sync_settings_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../config/offline_config.dart';
 
 class SyncSettingsScreen extends StatelessWidget {
   const SyncSettingsScreen({super.key});

--- a/mobile_app/lib/services/offline_catalog_service.dart
+++ b/mobile_app/lib/services/offline_catalog_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 


### PR DESCRIPTION
## Summary
- remove unused imports in app_database, main, sync_settings_screen, offline_catalog_service
- use super.key in SearchScreen constructor
- remove unused _getDirectoryService method
- clean up string interpolation and map spread in search screen

## Testing
- `npm test` *(fails: Missing script)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888014b41908327b1dd96f88c261213