### PR TITLE
Fix search spinner and bookmark sync

### DIFF
--- a/mobile_app/lib/screens/enhanced_cart_screen.dart
+++ b/mobile_app/lib/screens/enhanced_cart_screen.dart
@@ -6,6 +6,7 @@ import '../state/cart_state.dart';
 import '../state/saved_items_state.dart';
 import '../widgets/app_button.dart';
 import '../models/inventory_item.dart';
+import '../services/unified_saved_items_service.dart';
 
 class EnhancedCartScreen extends StatefulWidget {
   const EnhancedCartScreen({super.key});
@@ -478,6 +479,7 @@ class _EnhancedCartScreenState extends State<EnhancedCartScreen> {
                 Navigator.pop(context);
                 savedItemsState.addItem(item);
                 cart.removeItem(item);
+                UnifiedSavedItemsService.saveItem(context, item);
               },
             ),
             ListTile(
@@ -523,6 +525,10 @@ class _EnhancedCartScreenState extends State<EnhancedCartScreen> {
               onTap: () {
                 Navigator.pop(context);
                 savedItemsState.removeItem(item);
+                final itemId = item['id']?.toString() ?? item['code']?.toString();
+                if (itemId != null) {
+                  UnifiedSavedItemsService.removeItem(context, itemId);
+                }
               },
             ),
           ],

--- a/mobile_app/lib/screens/inventory_item_details_screen.dart
+++ b/mobile_app/lib/screens/inventory_item_details_screen.dart
@@ -35,6 +35,18 @@ class _InventoryItemDetailsScreenState extends State<InventoryItemDetailsScreen>
       isSaved = savedItemsState.hasItem(widget.item.code);
     });
   }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final savedItemsState = Provider.of<SavedItemsState>(context);
+    final saved = savedItemsState.hasItem(widget.item.code);
+    if (saved != isSaved) {
+      setState(() {
+        isSaved = saved;
+      });
+    }
+  }
   
   Future<void> _toggleSaveItem() async {
     // Convert InventoryItem to Map<String, dynamic>

--- a/mobile_app/lib/screens/search_screen_v2.dart
+++ b/mobile_app/lib/screens/search_screen_v2.dart
@@ -36,6 +36,7 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
   String _searchQuery = '';
   bool _isSearching = false;
   bool _hasResults = false;
+  bool _isLoading = false;
   
   // Search results
   List<Product> _productResults = [];
@@ -100,6 +101,7 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
       setState(() {
         _searchQuery = '';
         _isSearching = false;
+        _isLoading = false;
         _productResults = [];
         _colorResults = [];
         _typeGroupedResults = {};
@@ -114,6 +116,11 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
       setState(() {
         _searchQuery = trimmedQuery;
         _isSearching = true;
+        _isLoading = true;
+        _hasResults = false;
+        _productResults = [];
+        _colorResults = [];
+        _typeGroupedResults = {};
       });
       
       // For any search, ensure all product directories are loaded first
@@ -372,6 +379,7 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
     setState(() {
       _hasResults = hasAnyResults;
       _searchQuery = query;
+      _isLoading = false;
     });
   }
   
@@ -431,7 +439,11 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
           
           // Search results
           Expanded(
-            child: _isSearching ? _buildSearchResults() : _buildEmptyState(),
+            child: _searchQuery.isEmpty
+                ? _buildEmptyState()
+                : (_isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : _buildSearchResults()),
           ),
         ],
       ),
@@ -440,14 +452,26 @@ class _SearchScreenV2State extends State<SearchScreenV2> {
   
   Widget _buildEmptyState() {
     return const Center(
-      child: Text('Enter a search term to find products, colors, or inventory items'),
+      child: Text(
+        'Enter a search term to find products, colors, or inventory items',
+        style: TextStyle(
+          fontSize: 18,
+          color: Colors.white,
+          fontWeight: FontWeight.w600,
+        ),
+        textAlign: TextAlign.center,
+      ),
     );
   }
   
   Widget _buildSearchResults() {
     if (!_hasResults) {
       return Center(
-        child: Text('No results found for "$_searchQuery"'),
+        child: Text(
+          'No results found for "$_searchQuery"',
+          style: const TextStyle(color: Colors.white70),
+          textAlign: TextAlign.center,
+        ),
       );
     }
     


### PR DESCRIPTION
## Summary
- show a loading spinner for search screen v2 results
- improve accessibility text styling on empty search message
- sync saved-item state when removing items from cart
- update inventory item details when saved items change

## Testing
- `npx playwright test` *(fails: requires Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68880a9ae06c8327962b5b77a79ff874