### PR TITLE
Update edge-to-edge handling for Android 15

### DIFF
--- a/mobile_app/android/app/src/main/kotlin/com/example/mobile_app/MainActivity.kt
+++ b/mobile_app/android/app/src/main/kotlin/com/example/mobile_app/MainActivity.kt
@@ -1,15 +1,16 @@
 package com.angelgranites.app
 
 import android.os.Bundle
-import androidx.core.view.WindowCompat
+import androidx.activity.enableEdgeToEdge
 import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity : FlutterActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Enable edge-to-edge display using the modern API. This replaces
+        // deprecated calls such as window.setStatusBarColor and
+        // window.setNavigationBarColor.
+        enableEdgeToEdge()
+
         super.onCreate(savedInstanceState)
-        
-        // Enable edge-to-edge display for Android 15+ compatibility
-        // This replaces the deprecated window.setStatusBarColor, window.setNavigationBarColor, etc.
-        WindowCompat.setDecorFitsSystemWindows(window, false)
     }
 }

--- a/mobile_app/lib/screens/design_gallery_screen.dart
+++ b/mobile_app/lib/screens/design_gallery_screen.dart
@@ -14,16 +14,18 @@ class DesignGalleryScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Set preferred orientations and status bar style for better UX
+    // Set preferred orientations and enable modern edge-to-edge UI
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
     ]);
+    // Use edge-to-edge mode without modifying system bar colors, which avoids
+    // the deprecated Window.setStatusBarColor and setNavigationBarColor APIs.
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     SystemChrome.setSystemUIOverlayStyle(
       const SystemUiOverlayStyle(
-        statusBarColor: Colors.transparent,
         statusBarIconBrightness: Brightness.light,
       ),
     );

--- a/mobile_app_old/lib/screens/design_gallery_screen.dart
+++ b/mobile_app_old/lib/screens/design_gallery_screen.dart
@@ -14,16 +14,18 @@ class DesignGalleryScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Set preferred orientations and status bar style for better UX
+    // Set preferred orientations and enable modern edge-to-edge UI
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
     ]);
+    // Use edge-to-edge mode without modifying system bar colors, which avoids
+    // the deprecated Window.setStatusBarColor and setNavigationBarColor APIs.
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     SystemChrome.setSystemUIOverlayStyle(
       const SystemUiOverlayStyle(
-        statusBarColor: Colors.transparent,
         statusBarIconBrightness: Brightness.light,
       ),
     );


### PR DESCRIPTION
## Summary
- modernize edge-to-edge API usage in `MainActivity.kt`
- enable edge-to-edge mode without deprecated colors in gallery screen
- update old gallery code to match

## Testing
- `npm install`
- `npx playwright install chromium` *(failed: 403 Forbidden)*
- `npx playwright install-deps`
- `npx playwright test` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_68880d9842908327b1a11112caf48a0c