### PR TITLE
Implement specials API fetch in mobile app

### DIFF
--- a/mobile_app/lib/screens/home_screen.dart
+++ b/mobile_app/lib/screens/home_screen.dart
@@ -42,8 +42,7 @@ class _HomeScreenState extends State<HomeScreen> {
     _futureFeatured = widget.apiService.fetchFeaturedProducts();
     _futureInventorySummary =
         widget.inventoryService.fetchInventory(pageSize: 3);
-    _futureSpecials =
-        widget.apiService.loadLocalProducts('assets/specials.json');
+    _futureSpecials = widget.apiService.fetchSpecials();
     _directoryService = widget.directoryService;
   }
 
@@ -55,7 +54,7 @@ class _HomeScreenState extends State<HomeScreen> {
       _futureInventorySummary =
           widget.inventoryService.fetchInventory(pageSize: 3, forceRefresh: true);
       // Refresh specials
-      _futureSpecials = widget.apiService.loadLocalProducts('assets/specials.json');
+      _futureSpecials = widget.apiService.fetchSpecials(forceRefresh: true);
     });
   }
 


### PR DESCRIPTION
## Summary
- switch HomeScreen to load specials from server
- add `fetchSpecials` to `ApiService` with caching and offline fallback
- update local specials JSON when API succeeds

## Testing
- `npx playwright test tests/static.spec.js` *(fails: browser download blocked)*
- `npx playwright install chromium` *(fails: 403 domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d21cd63d48327878dacd7a1c64dea