### PR TITLE
Fix inventory scrolling on large iPads

### DIFF
--- a/mobile_app/lib/screens/inventory_screen.dart
+++ b/mobile_app/lib/screens/inventory_screen.dart
@@ -150,8 +150,10 @@ class _InventoryScreenState extends State<InventoryScreen> {
       },
       child: RefreshIndicator(
         onRefresh: _refreshData,
-        child: Column(
-      children: [
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: Column(
+            children: [
         // Search and filter section
         Padding(
           padding: const EdgeInsets.all(8.0),
@@ -247,12 +249,10 @@ class _InventoryScreenState extends State<InventoryScreen> {
           ),
         ),
         // Inventory table
-        Expanded(
-          child: InventoryTableSection(
-            title: 'Current Inventory',
-            future: _futureInventory,
-            onRetry: _loadInventory,
-          ),
+        InventoryTableSection(
+          title: 'Current Inventory',
+          future: _futureInventory,
+          onRetry: _loadInventory,
         ),
       ],
     ),

--- a/mobile_app/lib/widgets/inventory_table_section.dart
+++ b/mobile_app/lib/widgets/inventory_table_section.dart
@@ -464,11 +464,17 @@ class _InventoryTableSectionState extends State<InventoryTableSection> {
         // For larger screens, show a responsive data table
         return LayoutBuilder(
           builder: (context, constraints) {
-            return SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: ConstrainedBox(
-                constraints: BoxConstraints(minWidth: constraints.maxWidth),
-                child: DataTable(
+            return Scrollbar(
+              controller: _scrollController,
+              thumbVisibility: true,
+              child: SingleChildScrollView(
+                controller: _scrollController,
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(minWidth: constraints.maxWidth),
+                    child: DataTable(
                   columnSpacing: 16,
                   horizontalMargin: 12,
                   headingRowHeight: 56,
@@ -556,8 +562,8 @@ class _InventoryTableSectionState extends State<InventoryTableSection> {
                   }).toList(),
                 ),
               ),
-            );
-          },
+            ),
+          ),
         );
       },
     );


### PR DESCRIPTION
## Summary
- make inventory list scrollable so pull-to-refresh works
- allow inventory table to scroll vertically on large screens

## Testing
- `npx playwright test` *(fails: missing browsers)*

------
https://chatgpt.com/codex/tasks/task_e_688d3630d544832797bc598f7aa0d63d