### PR TITLE
Fix pull-to-refresh on large screens

### DIFF
--- a/mobile_app/lib/screens/colors_screen.dart
+++ b/mobile_app/lib/screens/colors_screen.dart
@@ -33,6 +33,7 @@ class _ColorsScreenState extends State<ColorsScreen> {
     return RefreshIndicator(
       onRefresh: _refreshData,
       child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
         child: ProductSection(
           title: 'Granite Varieties',
           future: _futureColors,

--- a/mobile_app/lib/screens/home_screen.dart
+++ b/mobile_app/lib/screens/home_screen.dart
@@ -65,6 +65,7 @@ class _HomeScreenState extends State<HomeScreen> {
       child: RefreshIndicator(
         onRefresh: _refreshData,
         child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
         child: Column(
           children: [
             // Header with Logo and Welcome

--- a/mobile_app/lib/screens/saved_items_screen.dart
+++ b/mobile_app/lib/screens/saved_items_screen.dart
@@ -93,6 +93,7 @@ class _SavedItemsScreenState extends State<SavedItemsScreen> {
     return RefreshIndicator(
       onRefresh: _loadSavedItems,
       child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(8),
         itemCount: _savedItems.length,
         itemBuilder: (context, index) {

--- a/mobile_app/lib/widgets/inventory_table_section.dart
+++ b/mobile_app/lib/widgets/inventory_table_section.dart
@@ -292,21 +292,27 @@ class _InventoryTableSectionState extends State<InventoryTableSection> {
         
         // Empty state
         if (!snapshot.hasData || snapshot.data!.isEmpty) {
-          return Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.inventory_2_outlined, 
-                    size: 64, 
-                    color: theme.hintColor.withValues(alpha: 0.5)),
-                const SizedBox(height: 16),
-                Text(
-                  'No items found',
-                  style: theme.textTheme.titleMedium,
+          return SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: SizedBox(
+              height: MediaQuery.of(context).size.height * 0.8,
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.inventory_2_outlined,
+                        size: 64,
+                        color: theme.hintColor.withValues(alpha: 0.5)),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No items found',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    const Text('Try adjusting your search or filters'),
+                  ],
                 ),
-                const SizedBox(height: 8),
-                const Text('Try adjusting your search or filters'),
-              ],
+              ),
             ),
           );
         }
@@ -319,6 +325,7 @@ class _InventoryTableSectionState extends State<InventoryTableSection> {
           children: [
             ListView.builder(
               controller: _scrollController,
+              physics: const AlwaysScrollableScrollPhysics(),
             padding: const EdgeInsets.all(8),
             itemCount: items.length,
               itemBuilder: (context, index) {
@@ -465,10 +472,12 @@ class _InventoryTableSectionState extends State<InventoryTableSection> {
         return LayoutBuilder(
           builder: (context, constraints) {
             return SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: ConstrainedBox(
-                constraints: BoxConstraints(minWidth: constraints.maxWidth),
-                child: DataTable(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minWidth: constraints.maxWidth),
+                  child: DataTable(
                   columnSpacing: 16,
                   horizontalMargin: 12,
                   headingRowHeight: 56,


### PR DESCRIPTION
## Summary
- ensure refresh works when inventory list is short
- allow scrolling in color list, saved items list and home screen even when content is small

## Testing
- `npx playwright test` *(fails: missing browsers/lib dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688d5453429083278ac698d1ae32dc73