### PR TITLE
Improve CSRF token handling in credit application

### DIFF
--- a/creditapp/index.php
+++ b/creditapp/index.php
@@ -1,9 +1,8 @@
 <?php
 // Credit Application Form for Angel Stones
 session_start();
-if (!isset($_SESSION['csrf_token'])) {
-    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-}
+// Always generate a fresh CSRF token for each form load
+$_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 $status = $_GET['status'] ?? '';
 $errors = [];
 if ($status === 'validation_error' && isset($_GET['errors'])) {
@@ -486,7 +485,7 @@ if ($status === 'validation_error' && isset($_GET['errors'])) {
         <div class="alert alert-danger">There was an error submitting the form. Please try again.</div>
     <?php endif; ?>
     <form action="submit.php" method="post" id="creditAppForm">
-        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
+        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>">
         <div class="form-section">
             <h4>1. Business Information</h4>
             <div class="form-section-inner">

--- a/creditapp/submit.php
+++ b/creditapp/submit.php
@@ -26,7 +26,10 @@ file_put_contents($debug_file, $debug_content, LOCK_EX);
 chmod($debug_file, 0666); // Ensure file is readable
 
 // CSRF token validation
-if (!isset($_POST['csrf_token']) || !isset($_SESSION['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+if (
+    !isset($_POST['csrf_token'], $_SESSION['csrf_token']) ||
+    !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
+) {
     $debug_content .= "CSRF validation failed\n";
     $debug_content .= "POST csrf_token: " . ($_POST['csrf_token'] ?? 'NOT SET') . "\n";
     $debug_content .= "SESSION csrf_token: " . ($_SESSION['csrf_token'] ?? 'NOT SET') . "\n";
@@ -37,6 +40,8 @@ if (!isset($_POST['csrf_token']) || !isset($_SESSION['csrf_token']) || $_POST['c
     exit;
 }
 
+// Invalidate token after successful validation to prevent reuse
+unset($_SESSION['csrf_token']);
 $debug_content .= "CSRF validation passed\n";
 
 // reCAPTCHA v3 validation (disabled for local testing)


### PR DESCRIPTION
## Summary
- Regenerate CSRF token on each credit application form load and sanitize the token field
- Validate CSRF token using constant-time comparison and invalidate it after successful submission

## Testing
- `php -l creditapp/index.php`
- `php -l creditapp/submit.php`
- `npx playwright test` *(fails: Check Navigation Bar Links)*

------
https://chatgpt.com/codex/tasks/task_e_68a11c20b7948327a5f720a71e8d23bf